### PR TITLE
Server info c#

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,9 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - test
-      - fmt
-      - clippy
+      - lint
       - docs
+      - build
+      - nupkg
     steps:
       - run: exit 0
 
@@ -42,24 +43,53 @@ jobs:
           makers deps
           cargo test
           makers undeps
-
-  fmt:
-    name: fmt
-    runs-on: ubuntu-latest
+    
+  build-mac:
+    name: build pitaya for mac
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
         with:
           submodules: true
+
       - name: Install Rust
         run: rustup update stable
-      - name: Install rustfmt
-        run: rustup component add rustfmt
 
-      # Check fmt
-      - name: "rustfmt --check"
-        run: cargo fmt -- --check
+      - name: Build Pitaya
+        run: cargo build --release
 
-  clippy:
+      - name: Upload Build Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: libpitaya.dylib
+          path: target/release/libpitaya.dylib
+
+  build-linux:
+    name: build pitaya for linux
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Install Rust
+        run: rustup update stable
+
+      - name: Build Pitaya
+        run: cargo build --release
+
+      - name: Upload Build Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: libpitaya.so
+          path: target/release/libpitaya.so
+
+  lint:
     name: clippy
     runs-on: ubuntu-latest
     steps:
@@ -70,6 +100,10 @@ jobs:
         run: rustup update stable
       - name: Install clippy
         run: rustup component add clippy
+
+      # Check fmt
+      - name: "rustfmt --check"
+        run: cargo fmt -- --check
 
       # Run clippy
       - name: "clippy --all"
@@ -90,3 +124,23 @@ jobs:
         run: cargo doc --lib --no-deps --all-features
         env:
           RUSTDOCFLAGS: --cfg docsrs
+
+  nupkg:
+    name: Create NuPkg
+    runs-on: ubuntu-latest
+    needs:
+      - build-linux
+      - build-mac
+    steps:
+      # Download Mac binary
+      - uses: actions/download-artifact@v2
+        with:
+          name: libpitaya.so
+          path: target/release
+      # Download Libnux binary
+      - uses: actions/download-artifact@v2
+        with:
+          name: libpitaya.dylib
+          path: target/release
+
+

--- a/pitaya-sharp/NPitaya/src/PitayaCluster.Native.cs
+++ b/pitaya-sharp/NPitaya/src/PitayaCluster.Native.cs
@@ -50,6 +50,7 @@ namespace NPitaya
             IntPtr logFunction,
             IntPtr logCtx,
             IntPtr customMetrics,
+            IntPtr serverInfo,
             out IntPtr pitaya);
         [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
         private static extern void pitaya_shutdown(IntPtr pitaya);

--- a/pitaya-sharp/NPitaya/src/PitayaCluster.RPC.cs
+++ b/pitaya-sharp/NPitaya/src/PitayaCluster.RPC.cs
@@ -1,9 +1,6 @@
 using System;
-using System.Diagnostics;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Google.Protobuf;
-using NPitaya.Metrics;
 using NPitaya.Models;
 using NPitaya.Serializer;
 using NPitaya.Protos;

--- a/pitaya-sharp/NPitaya/src/RpcClient.cs
+++ b/pitaya-sharp/NPitaya/src/RpcClient.cs
@@ -14,9 +14,10 @@ namespace NPitaya
         IntPtr _pitaya;
         ISerializer _serializer;
 
-        public RpcClient(IntPtr pitaya)
+        public RpcClient(IntPtr pitaya, ISerializer serializer)
         {
             _pitaya = pitaya;
+            _serializer = serializer;
         }
 
         public Task<T> Rpc<T>(string serverId, Route route, object msg)

--- a/pitaya-sharp/exampleapp/Program.cs
+++ b/pitaya-sharp/exampleapp/Program.cs
@@ -41,6 +41,13 @@ namespace PitayaCSharpExample
                 PitayaCluster.Initialize(
                     "CSHARP",
                     "csharp.toml",
+                    new Server(
+                        id: "c#-id",
+                        kind: "random-server-kind",
+                        metadata: "{}",
+                        hostname: "ololo",
+                        frontend: true
+                    ),
                     NativeLogLevel.Debug,
                     NativeLogKind.Console,
                     (msg) =>

--- a/src/pitaya/pitaya.h
+++ b/src/pitaya/pitaya.h
@@ -93,6 +93,7 @@ PitayaError *pitaya_initialize_with_nats(void *user_ctx,
                                          void (*log_function)(void*, char*),
                                          void *log_ctx,
                                          PitayaCustomMetrics *custom_metrics,
+                                         PitayaServerInfo *server_info,
                                          Pitaya **pitaya);
 
 void pitaya_metrics_inc_counter(Pitaya *p,

--- a/src/pitaya/src/constants.rs
+++ b/src/pitaya/src/constants.rs
@@ -4,8 +4,6 @@ pub const DEFAULT_ENV_PREFIX: &str = "PITAYA";
 
 pub const DEFAULT_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(30);
 
-pub const DEFAULT_SERVER_KIND: &str = "pitaya";
-
 pub const DEFAULT_METRICS_URL: &str = "127.0.0.1:8000";
 pub const DEFAULT_METRICS_PATH: &str = "/metrics";
 pub const DEFAULT_METRICS_NAMESPACE: &str = "pitaya";

--- a/src/pitaya/src/settings.rs
+++ b/src/pitaya/src/settings.rs
@@ -51,9 +51,6 @@ pub struct Settings {
     // NATS related settings.
     pub nats: pitaya_etcd_nats_cluster::settings::Nats,
 
-    // The kind of this server. For example, "metagame" to represent a metagame server.
-    pub server_kind: String,
-
     // Metrics related settings.
     pub metrics: Metrics,
 }
@@ -65,7 +62,6 @@ impl Default for Settings {
             shutdown_timeout: constants::DEFAULT_SHUTDOWN_TIMEOUT,
             etcd: Default::default(),
             nats: Default::default(),
-            server_kind: constants::DEFAULT_SERVER_KIND.to_owned(),
             metrics: Default::default(),
         }
     }


### PR DESCRIPTION
Add support for passing the server info from C#.

This commit removes the necessity of passing the server_kind form the config file, and it is not passed as a parameter to the Initialize function.