### PR TITLE
correctly parse rpc response in C#

### DIFF
--- a/pitaya-sharp/NPitaya/NPitaya.csproj
+++ b/pitaya-sharp/NPitaya/NPitaya.csproj
@@ -4,7 +4,7 @@
     <PropertyGroup>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <PackageId>NPitaya</PackageId>
-        <PackageVersion>0.13.0</PackageVersion>
+        <PackageVersion>0.13.1</PackageVersion>
         <Title>NPitaya</Title>
         <Authors>TFG Co</Authors>
         <Description>A full implementation of pitaya backend framework for .NET</Description>

--- a/pitaya-sharp/NPitaya/src/Serializer/JSONSerializer.cs
+++ b/pitaya-sharp/NPitaya/src/Serializer/JSONSerializer.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Text;
-using PitayaSimpleJson;
 
 namespace NPitaya.Serializer
 {

--- a/pitaya-sharp/exampleapp/exampleapp.csproj
+++ b/pitaya-sharp/exampleapp/exampleapp.csproj
@@ -7,7 +7,7 @@
 
     <ItemGroup>
         <!-- <ProjectReference Include="..\NPitaya\NPitaya.csproj" /> -->
-        <PackageReference Include="NPitaya" Version="0.13.0" />
+        <PackageReference Include="NPitaya" Version="0.13.1" />
     </ItemGroup>
 
     <!-- <Target Name="PreBuild" BeforeTargets="PreBuildEvent"> -->


### PR DESCRIPTION
Before this PR, we were incorrectly parsing a byte string into the Type from the RPC call. This is incorrect since the result of an RPC call is wrapped into the Protos.Response protobuf message. So now we're first unwrapping the response and then unmarshalling the response from the RPC.