### PR TITLE
Add language and system resource metrics

### DIFF
--- a/pitaya-sharp/NPitaya/NPitaya.csproj
+++ b/pitaya-sharp/NPitaya/NPitaya.csproj
@@ -19,8 +19,10 @@
 
     <ItemGroup>
         <PackageReference Include="Google.Protobuf" Version="3.7.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.9" />
         <PackageReference Include="prometheus-net" Version="4.0.0" />
         <PackageReference Include="prometheus-net.DotNetRuntime" Version="3.4.0" />
+        <PackageReference Include="prometheus-net.SystemMetrics" Version="1.0.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/pitaya-sharp/NPitaya/NPitaya.csproj
+++ b/pitaya-sharp/NPitaya/NPitaya.csproj
@@ -20,6 +20,7 @@
     <ItemGroup>
         <PackageReference Include="Google.Protobuf" Version="3.7.0" />
         <PackageReference Include="prometheus-net" Version="4.0.0" />
+        <PackageReference Include="prometheus-net.DotNetRuntime" Version="3.4.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/pitaya-sharp/NPitaya/NPitaya.csproj
+++ b/pitaya-sharp/NPitaya/NPitaya.csproj
@@ -13,7 +13,8 @@
         <RepositoryUrl>https://github.com/topfreegames/libpitaya-cluster</RepositoryUrl>
         <PackageTags>pitaya,server,games,framework,rpc</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <TargetFrameworks>net461;netstandard2.0;netcoreapp3.1</TargetFrameworks>
+        <!-- TODO (felipe.rodopoulos): reintroduce net461 here. DotNetRuntime metrics collections does not support it, but it need it in Unity envs. -->
+        <TargetFrameworks>netstandard2.1;netcoreapp3.1</TargetFrameworks>
         <RootNamespace>pitaya</RootNamespace>
     </PropertyGroup>
 

--- a/pitaya-sharp/NPitaya/NPitaya.csproj
+++ b/pitaya-sharp/NPitaya/NPitaya.csproj
@@ -16,6 +16,8 @@
         <!-- TODO (felipe.rodopoulos): reintroduce net461 here. DotNetRuntime metrics collections does not support it, but it need it in Unity envs. -->
         <TargetFrameworks>netstandard2.1;netcoreapp3.1</TargetFrameworks>
         <RootNamespace>pitaya</RootNamespace>
+
+        <Nullable>enable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/pitaya-sharp/NPitaya/src/Metrics/MetricsConfiguration.cs
+++ b/pitaya-sharp/NPitaya/src/Metrics/MetricsConfiguration.cs
@@ -2,12 +2,14 @@ namespace NPitaya.Metrics
 {
     public class MetricsConfiguration
     {
+        internal readonly bool IsEnabled;
         internal readonly string Host;
         internal readonly string Port;
         internal readonly string Namespace;
 
-        public MetricsConfiguration(string host, string port, string ns)
+        public MetricsConfiguration(bool isEnabled, string host, string port, string ns)
         {
+            IsEnabled = isEnabled;
             Host = host;
             Port = port;
             Namespace = ns;

--- a/pitaya-sharp/NPitaya/src/Metrics/MetricsReporter.cs
+++ b/pitaya-sharp/NPitaya/src/Metrics/MetricsReporter.cs
@@ -4,34 +4,23 @@ namespace NPitaya.Metrics
 {
     class MetricsReporter
     {
-        readonly bool _isEnabled;
         readonly PrometheusReporter _prometheusServer;
         readonly PitayaReporter _pitayaMetrics ;
 
         internal MetricsReporter(MetricsConfiguration config)
         {
-            _isEnabled = config.IsEnabled;
-            if (!_isEnabled)
-            {
-                return;
-            }
             _prometheusServer = new PrometheusReporter(config);
             _pitayaMetrics = new PitayaReporter(_prometheusServer);
         }
 
         internal void Start()
         {
-            if (!_isEnabled)
-            {
-                return;
-            }
-
             _prometheusServer.Start();
         }
 
-        internal IntPtr GetPitayaPrt()
+        internal IntPtr GetPitayaPtr()
         {
-            return !_isEnabled ? IntPtr.Zero : _pitayaMetrics.Ptr;
+            return _pitayaMetrics.Ptr;
         }
     }
 }

--- a/pitaya-sharp/NPitaya/src/Metrics/MetricsReporter.cs
+++ b/pitaya-sharp/NPitaya/src/Metrics/MetricsReporter.cs
@@ -1,103 +1,37 @@
 using System;
-using System.Runtime.InteropServices;
-using NPitaya.Models;
 
 namespace NPitaya.Metrics
 {
-    public class MetricsReporter
+    class MetricsReporter
     {
-        const string LabelSeparator = "_";
-        const string PitayaSubsystem = "pitaya";
+        readonly bool _isEnabled;
+        readonly PrometheusReporter _prometheusServer;
+        readonly PitayaReporter _pitayaMetrics ;
 
-        public IntPtr Ptr { get; }
-
-        public MetricsReporter(PrometheusReporter prometheusReporter)
+        internal MetricsReporter(MetricsConfiguration config)
         {
-            var handle = GCHandle.Alloc(prometheusReporter, GCHandleType.Normal);
-            var reporterPtr = GCHandle.ToIntPtr(handle);
-            Ptr = PitayaCluster.pitaya_metrics_reporter_new(
-                RegisterCounterFn,
-                RegisterHistogramFn,
-                RegisterGaugeFn,
-                IncCounterFn,
-                ObserveHistFn,
-                SetGaugeFn,
-                AddGaugeFn,
-                reporterPtr);
+            _isEnabled = config.IsEnabled;
+            if (!_isEnabled)
+            {
+                return;
+            }
+            _prometheusServer = new PrometheusReporter(config);
+            _pitayaMetrics = new PitayaReporter(_prometheusServer);
         }
 
-        ~MetricsReporter()
+        internal void Start()
         {
-            PitayaCluster.pitaya_metrics_reporter_drop(Ptr);
+            if (!_isEnabled)
+            {
+                return;
+            }
+
+            _prometheusServer.Start();
         }
 
-        static void RegisterCounterFn(IntPtr prometheusPtr, MetricsOpts opts)
+        internal IntPtr GetPitayaPrt()
         {
-            var ns = Marshal.PtrToStringAnsi(opts.MetricNamespace);
-            // TODO (felipe.rodopoulos): prometheus-net does not support subsystem label yet. We'll use a hardcoded one.
-            var name = Marshal.PtrToStringAnsi(opts.Name);
-            var prometheusReporter = RetrievePrometheus(prometheusPtr);
-            var key = BuildKey(name);
-            prometheusReporter.RegisterCounter(key);
-        }
-
-        static void RegisterHistogramFn(IntPtr prometheusPtr, MetricsOpts opts)
-        {
-            var ns = Marshal.PtrToStringAnsi(opts.MetricNamespace);
-            // TODO (felipe.rodopoulos): prometheus-net does not support subsystem label yet. We'll use a hardcoded one.
-            var name = Marshal.PtrToStringAnsi(opts.Name);
-            var prometheusReporter = RetrievePrometheus(prometheusPtr);
-            var key = BuildKey(name);
-            prometheusReporter.RegisterHistogram(key);
-        }
-
-        static void RegisterGaugeFn(IntPtr prometheusPtr, MetricsOpts opts)
-        {
-            var ns = Marshal.PtrToStringAnsi(opts.MetricNamespace);
-            // TODO (felipe.rodopoulos): prometheus-net does not support subsystem label yet. We'll use a hardcoded one.
-            var name = Marshal.PtrToStringAnsi(opts.Name);
-            var prometheusReporter = RetrievePrometheus(prometheusPtr);
-            var key = BuildKey(name);
-            prometheusReporter.RegisterGauge(key);
-        }
-
-        static void IncCounterFn(IntPtr prometheusPtr, IntPtr name, ref IntPtr labels, UInt32 labelsCount)
-        {
-            string nameStr = Marshal.PtrToStringAnsi(name);
-            var prometheus = RetrievePrometheus(prometheusPtr);
-            prometheus.IncCounter(nameStr);
-        }
-
-        static void ObserveHistFn(IntPtr prometheusPtr, IntPtr name, double value, ref IntPtr labels, UInt32 labelsCount)
-        {
-            string nameStr = Marshal.PtrToStringAnsi(name);
-            var key = BuildKey(nameStr);
-            var prometheus = RetrievePrometheus(prometheusPtr);
-            prometheus.ObserveHistogram(key, value);
-        }
-
-        static void SetGaugeFn(IntPtr prometheusPtr, IntPtr name, double value, ref IntPtr labels, UInt32 labelsCount)
-        {
-            string nameStr = Marshal.PtrToStringAnsi(name);
-            var prometheus = RetrievePrometheus(prometheusPtr);
-            prometheus.SetGauge(nameStr, value);
-        }
-
-        static void AddGaugeFn(IntPtr prometheusPtr, IntPtr name, double value, ref IntPtr labels, UInt32 labelsCount)
-        {
-            string nameStr = Marshal.PtrToStringAnsi(name);
-            Logger.Warn($"Adding gauge {nameStr} with val {value}. This method should not be used.");
-        }
-
-        private static PrometheusReporter RetrievePrometheus(IntPtr ptr)
-        {
-            var handle = GCHandle.FromIntPtr(ptr);
-            return handle.Target as PrometheusReporter;
-        }
-
-        private static string BuildKey(string suffix)
-        {
-            return $"{PitayaSubsystem}{LabelSeparator}{suffix}";
+            return !_isEnabled ? IntPtr.Zero : _pitayaMetrics.Ptr;
         }
     }
 }

--- a/pitaya-sharp/NPitaya/src/Metrics/PitayaReporter.cs
+++ b/pitaya-sharp/NPitaya/src/Metrics/PitayaReporter.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Runtime.InteropServices;
+using NPitaya.Models;
+
+namespace NPitaya.Metrics
+{
+    public class PitayaReporter
+    {
+        const string LabelSeparator = "_";
+        const string PitayaSubsystem = "pitaya";
+
+        public IntPtr Ptr { get; }
+
+        public PitayaReporter(PrometheusReporter prometheusReporter)
+        {
+            var handle = GCHandle.Alloc(prometheusReporter, GCHandleType.Normal);
+            var reporterPtr = GCHandle.ToIntPtr(handle);
+            Ptr = PitayaCluster.pitaya_metrics_reporter_new(
+                RegisterCounterFn,
+                RegisterHistogramFn,
+                RegisterGaugeFn,
+                IncCounterFn,
+                ObserveHistFn,
+                SetGaugeFn,
+                AddGaugeFn,
+                reporterPtr);
+        }
+
+        ~PitayaReporter()
+        {
+            PitayaCluster.pitaya_metrics_reporter_drop(Ptr);
+        }
+
+        static void RegisterCounterFn(IntPtr prometheusPtr, MetricsOpts opts)
+        {
+            var ns = Marshal.PtrToStringAnsi(opts.MetricNamespace);
+            // TODO (felipe.rodopoulos): prometheus-net does not support subsystem label yet. We'll use a hardcoded one.
+            var name = Marshal.PtrToStringAnsi(opts.Name);
+            var prometheusReporter = RetrievePrometheus(prometheusPtr);
+            var key = BuildKey(name);
+            prometheusReporter.RegisterCounter(key);
+        }
+
+        static void RegisterHistogramFn(IntPtr prometheusPtr, MetricsOpts opts)
+        {
+            var ns = Marshal.PtrToStringAnsi(opts.MetricNamespace);
+            // TODO (felipe.rodopoulos): prometheus-net does not support subsystem label yet. We'll use a hardcoded one.
+            var name = Marshal.PtrToStringAnsi(opts.Name);
+            var prometheusReporter = RetrievePrometheus(prometheusPtr);
+            var key = BuildKey(name);
+            prometheusReporter.RegisterHistogram(key);
+        }
+
+        static void RegisterGaugeFn(IntPtr prometheusPtr, MetricsOpts opts)
+        {
+            var ns = Marshal.PtrToStringAnsi(opts.MetricNamespace);
+            // TODO (felipe.rodopoulos): prometheus-net does not support subsystem label yet. We'll use a hardcoded one.
+            var name = Marshal.PtrToStringAnsi(opts.Name);
+            var prometheusReporter = RetrievePrometheus(prometheusPtr);
+            var key = BuildKey(name);
+            prometheusReporter.RegisterGauge(key);
+        }
+
+        static void IncCounterFn(IntPtr prometheusPtr, IntPtr name, ref IntPtr labels, UInt32 labelsCount)
+        {
+            string nameStr = Marshal.PtrToStringAnsi(name);
+            var prometheus = RetrievePrometheus(prometheusPtr);
+            prometheus.IncCounter(nameStr);
+        }
+
+        static void ObserveHistFn(IntPtr prometheusPtr, IntPtr name, double value, ref IntPtr labels, UInt32 labelsCount)
+        {
+            string nameStr = Marshal.PtrToStringAnsi(name);
+            var key = BuildKey(nameStr);
+            var prometheus = RetrievePrometheus(prometheusPtr);
+            prometheus.ObserveHistogram(key, value);
+        }
+
+        static void SetGaugeFn(IntPtr prometheusPtr, IntPtr name, double value, ref IntPtr labels, UInt32 labelsCount)
+        {
+            string nameStr = Marshal.PtrToStringAnsi(name);
+            var prometheus = RetrievePrometheus(prometheusPtr);
+            prometheus.SetGauge(nameStr, value);
+        }
+
+        static void AddGaugeFn(IntPtr prometheusPtr, IntPtr name, double value, ref IntPtr labels, UInt32 labelsCount)
+        {
+            string nameStr = Marshal.PtrToStringAnsi(name);
+            Logger.Warn($"Adding gauge {nameStr} with val {value}. This method should not be used.");
+        }
+
+        private static PrometheusReporter RetrievePrometheus(IntPtr ptr)
+        {
+            var handle = GCHandle.FromIntPtr(ptr);
+            return handle.Target as PrometheusReporter;
+        }
+
+        private static string BuildKey(string suffix)
+        {
+            return $"{PitayaSubsystem}{LabelSeparator}{suffix}";
+        }
+    }
+}

--- a/pitaya-sharp/NPitaya/src/Metrics/PrometheusReporter.cs
+++ b/pitaya-sharp/NPitaya/src/Metrics/PrometheusReporter.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using NPitaya.Models;
 using Prometheus;
+using Prometheus.DotNetRuntime;
 
 namespace NPitaya.Metrics
 {
@@ -10,8 +11,9 @@ namespace NPitaya.Metrics
 
         readonly string _host;
         readonly int _port;
-        readonly MetricServer _server;
         readonly string _namespace;
+        readonly MetricServer _server;
+        readonly DotNetRuntimeStatsBuilder.Builder _dotnetCollector;
 
         readonly Dictionary<string, Counter> _counters;
         readonly Dictionary<string, Gauge> _gauges;
@@ -32,11 +34,19 @@ namespace NPitaya.Metrics
             _counters = new Dictionary<string, Counter>();
             _gauges = new Dictionary<string, Gauge>();
             _histograms = new Dictionary<string, Histogram>();
+            _dotnetCollector = DotNetRuntimeStatsBuilder
+                .Customize()
+                .WithContentionStats()
+                .WithThreadPoolSchedulingStats()
+                .WithThreadPoolStats()
+                .WithGcStats()
+                .WithExceptionStats();
         }
 
         internal void Start()
         {
             Logger.Info("Starting Prometheus metrics server at {0}:{1}", _host, _port);
+            _dotnetCollector?.StartCollecting();
             _server.Start();
         }
 

--- a/pitaya-sharp/NPitaya/src/Metrics/PrometheusReporter.cs
+++ b/pitaya-sharp/NPitaya/src/Metrics/PrometheusReporter.cs
@@ -1,7 +1,10 @@
 using System.Collections.Generic;
+using System.Security.Authentication.ExtendedProtection;
+using Microsoft.Extensions.DependencyInjection;
 using NPitaya.Models;
 using Prometheus;
 using Prometheus.DotNetRuntime;
+using Prometheus.SystemMetrics;
 
 namespace NPitaya.Metrics
 {
@@ -14,6 +17,7 @@ namespace NPitaya.Metrics
         readonly string _namespace;
         readonly MetricServer _server;
         readonly DotNetRuntimeStatsBuilder.Builder _dotnetCollector;
+        readonly IServiceCollection _systemMetrics;
 
         readonly Dictionary<string, Counter> _counters;
         readonly Dictionary<string, Gauge> _gauges;
@@ -41,12 +45,14 @@ namespace NPitaya.Metrics
                 .WithThreadPoolStats()
                 .WithGcStats()
                 .WithExceptionStats();
+            _systemMetrics = new ServiceCollection();
         }
 
         internal void Start()
         {
             Logger.Info("Starting Prometheus metrics server at {0}:{1}", _host, _port);
             _dotnetCollector?.StartCollecting();
+            _systemMetrics.AddSystemMetrics();
             _server.Start();
         }
 

--- a/pitaya-sharp/NPitaya/src/PitayaCluster.API.cs
+++ b/pitaya-sharp/NPitaya/src/PitayaCluster.API.cs
@@ -29,7 +29,7 @@ namespace NPitaya
         private static LogFunction logFunctionCallback;
         private static RpcClient _rpcClient;
         private static Action _onSignalEvent;
-        private static PrometheusReporter _metricsReporter;
+        private static MetricsReporter _metricsReporter;
 
         public enum ServiceDiscoveryAction
         {
@@ -110,8 +110,7 @@ namespace NPitaya
             logFunctionCallback = new LogFunction(LogFunctionCallback);
             var logCtx = GCHandle.Alloc(logFunction, GCHandleType.Normal);
 
-            _metricsReporter = new PrometheusReporter(metricsConfig);
-            var pitayaMetrics = new MetricsReporter(_metricsReporter);
+            _metricsReporter = new MetricsReporter(metricsConfig);
 
             IntPtr err = pitaya_initialize_with_nats(
                 IntPtr.Zero,
@@ -123,7 +122,7 @@ namespace NPitaya
                 logKind,
                 Marshal.GetFunctionPointerForDelegate(logFunctionCallback),
                 GCHandle.ToIntPtr(logCtx),
-                pitayaMetrics.Ptr,
+                _metricsReporter.GetPitayaPrt(),
                 serverInfo.Handle,
                 out pitaya
             );

--- a/pitaya-sharp/NPitaya/src/PitayaCluster.Native.cs
+++ b/pitaya-sharp/NPitaya/src/PitayaCluster.Native.cs
@@ -63,7 +63,7 @@ namespace NPitaya
             NativeLogKind logKind,
             IntPtr logFunction,
             IntPtr logCtx,
-            IntPtr rawMetricsReporter,
+            IntPtr? rawMetricsReporter,
             IntPtr serverInfo,
             out IntPtr pitaya);
         [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]


### PR DESCRIPTION
In this PR, we add language environment and system resource metrics, using external libraries. Due to the former one, we need to deprecated `net461` for now. Also, we added a feature flag for metrics.