### PR TITLE
Add custom metrics and metrics labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ You can find the C# implementation [here](./pitaya-sharp/README.md).
 The library needs to be build with the minimum Rust version of 1.46. Also, the library
 uses ETCD and NATS for implementing service discovery and RPC communication between servers.
 
+# Cloning
+You have to clone with recursive flag to clone all submodules too.
+```
+git clone --recursive https://github.com/tfgco/pitaya-rs
+```
+
 # Building
 You can build normally as any rust crate:
 ```
@@ -43,10 +49,19 @@ cd examples/c
 ./build.sh && ./example
 ```
 
+# C# Examples
+
 The C# example is found in the `pitaya-sharp/exampleapp` directory and can be run with the following commands:
 ```
 cd pitaya-sharp
 dotnet run -p exampleapp
+```
+
+To build `NPitaya` you need both a `libpitaya.dylib` and `libpitaya.so` in your target folder.
+So to run on OSX you may need to create an empty `libpitaya.so`:
+```
+cd pitaya-rs
+touch ./target/release/libpitaya.so
 ```
 
 # Benchmarks

--- a/pitaya-sharp/CHANGELOG.md
+++ b/pitaya-sharp/CHANGELOG.md
@@ -4,9 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.14.0] - 2020-10-26
 ### Added
 - Now it is possible to implement the MetricsReporter interface through FFI.
+- Prometheus metrics server at C# level, with system resources and language environment metrics.
 ### Changed
 - A metrics reporter needs to be manually provided in the PitayaBuilder.
 ### Removed

--- a/pitaya-sharp/NPitaya/NPitaya.csproj
+++ b/pitaya-sharp/NPitaya/NPitaya.csproj
@@ -4,7 +4,7 @@
     <PropertyGroup>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <PackageId>NPitaya</PackageId>
-        <PackageVersion>0.13.1</PackageVersion>
+        <PackageVersion>0.14.0</PackageVersion>
         <Title>NPitaya</Title>
         <Authors>TFG Co</Authors>
         <Description>A full implementation of pitaya backend framework for .NET</Description>

--- a/pitaya-sharp/NPitaya/src/Metrics/CustomMetrics.cs
+++ b/pitaya-sharp/NPitaya/src/Metrics/CustomMetrics.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+
+namespace NPitaya.Metrics
+{
+
+    internal readonly struct MetricSpec
+    {
+        internal readonly string Name;
+        internal readonly string Help;
+        internal readonly string[] Labels;
+
+        internal MetricSpec(string name, string help, string[] labels)
+        {
+            Name = name;
+            Help = help;
+            Labels = labels;
+        }
+    }
+
+    public class CustomMetrics
+    {
+        internal readonly List<MetricSpec> Counters;
+        internal readonly List<MetricSpec> Gauges;
+        internal readonly List<MetricSpec> Histograms;
+
+        public CustomMetrics()
+        {
+            Counters = new List<MetricSpec>();
+            Gauges = new List<MetricSpec>();
+            Histograms = new List<MetricSpec>();
+        }
+
+        public void AddCounter(string name, string help, string[] labels)
+        {
+            Counters.Add(new MetricSpec(name, help, labels));
+        }
+
+        public void AddGauge(string name, string help, string[] labels)
+        {
+            Gauges.Add(new MetricSpec(name, help, labels));
+        }
+
+        public void AddHistogram(string name, string help, string[] labels)
+        {
+            Histograms.Add(new MetricSpec(name, help, labels));
+        }
+    }
+}

--- a/pitaya-sharp/NPitaya/src/Metrics/CustomMetrics.cs
+++ b/pitaya-sharp/NPitaya/src/Metrics/CustomMetrics.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 
 namespace NPitaya.Metrics
 {
-
     internal readonly struct MetricSpec
     {
         internal readonly string Name;
@@ -30,17 +29,17 @@ namespace NPitaya.Metrics
             Histograms = new List<MetricSpec>();
         }
 
-        public void AddCounter(string name, string help, string[] labels)
+        public void AddCounter(string name, string help = null, string[] labels = null)
         {
             Counters.Add(new MetricSpec(name, help, labels));
         }
 
-        public void AddGauge(string name, string help, string[] labels)
+        public void AddGauge(string name, string help = null, string[] labels = null)
         {
             Gauges.Add(new MetricSpec(name, help, labels));
         }
 
-        public void AddHistogram(string name, string help, string[] labels)
+        public void AddHistogram(string name, string help = null, string[] labels = null)
         {
             Histograms.Add(new MetricSpec(name, help, labels));
         }

--- a/pitaya-sharp/NPitaya/src/Metrics/MetricsConfiguration.cs
+++ b/pitaya-sharp/NPitaya/src/Metrics/MetricsConfiguration.cs
@@ -6,9 +6,9 @@ namespace NPitaya.Metrics
         internal readonly string Host;
         internal readonly string Port;
         internal readonly string Namespace;
-        internal readonly CustomMetrics CustomMetrics;
+        internal readonly CustomMetrics? CustomMetrics;
 
-        public MetricsConfiguration(bool isEnabled, string host, string port, string ns, CustomMetrics customMetrics = null)
+        public MetricsConfiguration(bool isEnabled, string host, string port, string ns, CustomMetrics? customMetrics)
         {
             IsEnabled = isEnabled;
             Host = host;

--- a/pitaya-sharp/NPitaya/src/Metrics/MetricsConfiguration.cs
+++ b/pitaya-sharp/NPitaya/src/Metrics/MetricsConfiguration.cs
@@ -6,13 +6,15 @@ namespace NPitaya.Metrics
         internal readonly string Host;
         internal readonly string Port;
         internal readonly string Namespace;
+        internal readonly CustomMetrics CustomMetrics;
 
-        public MetricsConfiguration(bool isEnabled, string host, string port, string ns)
+        public MetricsConfiguration(bool isEnabled, string host, string port, string ns, CustomMetrics customMetrics = null)
         {
             IsEnabled = isEnabled;
             Host = host;
             Port = port;
             Namespace = ns;
+            CustomMetrics = customMetrics;
         }
     }
 }

--- a/pitaya-sharp/NPitaya/src/Metrics/MetricsReporter.cs
+++ b/pitaya-sharp/NPitaya/src/Metrics/MetricsReporter.cs
@@ -22,5 +22,20 @@ namespace NPitaya.Metrics
         {
             return _pitayaMetrics.Ptr;
         }
+
+        internal void IncCounter(string name)
+        {
+            _prometheusServer.IncCounter(name);
+        }
+
+        internal void SetGauge(string name, float value)
+        {
+            _prometheusServer.SetGauge(name, value);
+        }
+
+        internal void ObserveHistogram(string name, float value)
+        {
+            _prometheusServer.ObserveHistogram(name, value);
+        }
     }
 }

--- a/pitaya-sharp/NPitaya/src/Metrics/MetricsReporter.cs
+++ b/pitaya-sharp/NPitaya/src/Metrics/MetricsReporter.cs
@@ -23,19 +23,19 @@ namespace NPitaya.Metrics
             return _pitayaMetrics.Ptr;
         }
 
-        internal void IncCounter(string name)
+        internal void IncCounter(string name, string[]? labels)
         {
-            _prometheusServer.IncCounter(name);
+            _prometheusServer.IncCounter(name, labels);
         }
 
-        internal void SetGauge(string name, float value)
+        internal void SetGauge(string name, float value, string[]? labels)
         {
-            _prometheusServer.SetGauge(name, value);
+            _prometheusServer.SetGauge(name, value, labels);
         }
 
-        internal void ObserveHistogram(string name, float value)
+        internal void ObserveHistogram(string name, float value, string[]? labels)
         {
-            _prometheusServer.ObserveHistogram(name, value);
+            _prometheusServer.ObserveHistogram(name, value, labels);
         }
     }
 }

--- a/pitaya-sharp/NPitaya/src/Metrics/PitayaReporter.cs
+++ b/pitaya-sharp/NPitaya/src/Metrics/PitayaReporter.cs
@@ -6,6 +6,7 @@ namespace NPitaya.Metrics
 {
     public class PitayaReporter
     {
+        static readonly string[] NoLabels = new string[0];
         const string LabelSeparator = "_";
         const string PitayaSubsystem = "pitaya";
 
@@ -129,6 +130,27 @@ namespace NPitaya.Metrics
         {
             var handle = GCHandle.FromIntPtr(ptr);
             return handle.Target as PrometheusReporter;
+        }
+
+        static unsafe string[] ReadLabels(ref IntPtr labelsPtr, UInt32 size)
+        {
+            if (size == 0)
+            {
+                return NoLabels;
+            }
+
+            var ptr = (IntPtr*) labelsPtr;
+            var labels = new string[size];
+            for (var i = 0; i < size; i++)
+            {
+                var label = Marshal.PtrToStringAnsi(ptr[i]);
+                if (label != null)
+                {
+                    labels[i] = label;
+                }
+            }
+
+            return labels;
         }
 
         private static string BuildKey(string suffix)

--- a/pitaya-sharp/NPitaya/src/Metrics/PitayaReporter.cs
+++ b/pitaya-sharp/NPitaya/src/Metrics/PitayaReporter.cs
@@ -36,9 +36,11 @@ namespace NPitaya.Metrics
             var ns = Marshal.PtrToStringAnsi(opts.MetricNamespace);
             // TODO (felipe.rodopoulos): prometheus-net does not support subsystem label yet. We'll use a hardcoded one.
             var name = Marshal.PtrToStringAnsi(opts.Name);
+            var help = Marshal.PtrToStringAnsi(opts.Help);
+            var labels = Marshal.PtrToStructure<string[]>(opts.VariableLabels);
             var prometheusReporter = RetrievePrometheus(prometheusPtr);
             var key = BuildKey(name);
-            prometheusReporter.RegisterCounter(key);
+            prometheusReporter.RegisterCounter(key, help, labels);
         }
 
         static void RegisterHistogramFn(IntPtr prometheusPtr, MetricsOpts opts)
@@ -46,9 +48,11 @@ namespace NPitaya.Metrics
             var ns = Marshal.PtrToStringAnsi(opts.MetricNamespace);
             // TODO (felipe.rodopoulos): prometheus-net does not support subsystem label yet. We'll use a hardcoded one.
             var name = Marshal.PtrToStringAnsi(opts.Name);
+            var help = Marshal.PtrToStringAnsi(opts.Help);
+            var labels = Marshal.PtrToStructure<string[]>(opts.VariableLabels);
             var prometheusReporter = RetrievePrometheus(prometheusPtr);
             var key = BuildKey(name);
-            prometheusReporter.RegisterHistogram(key);
+            prometheusReporter.RegisterHistogram(key, help, labels);
         }
 
         static void RegisterGaugeFn(IntPtr prometheusPtr, MetricsOpts opts)
@@ -56,31 +60,36 @@ namespace NPitaya.Metrics
             var ns = Marshal.PtrToStringAnsi(opts.MetricNamespace);
             // TODO (felipe.rodopoulos): prometheus-net does not support subsystem label yet. We'll use a hardcoded one.
             var name = Marshal.PtrToStringAnsi(opts.Name);
+            var help = Marshal.PtrToStringAnsi(opts.Help);
+            var labels = Marshal.PtrToStructure<string[]>(opts.VariableLabels);
             var prometheusReporter = RetrievePrometheus(prometheusPtr);
             var key = BuildKey(name);
-            prometheusReporter.RegisterGauge(key);
+            prometheusReporter.RegisterGauge(key, help, labels);
         }
 
         static void IncCounterFn(IntPtr prometheusPtr, IntPtr name, ref IntPtr labels, UInt32 labelsCount)
         {
             string nameStr = Marshal.PtrToStringAnsi(name);
+            var labelsArr = Marshal.PtrToStructure<string[]>(labels);
             var prometheus = RetrievePrometheus(prometheusPtr);
-            prometheus.IncCounter(nameStr);
+            prometheus.IncCounter(nameStr, labelsArr);
         }
 
         static void ObserveHistFn(IntPtr prometheusPtr, IntPtr name, double value, ref IntPtr labels, UInt32 labelsCount)
         {
             string nameStr = Marshal.PtrToStringAnsi(name);
             var key = BuildKey(nameStr);
+            var labelsArr = Marshal.PtrToStructure<string[]>(labels);
             var prometheus = RetrievePrometheus(prometheusPtr);
-            prometheus.ObserveHistogram(key, value);
+            prometheus.ObserveHistogram(key, value, labelsArr);
         }
 
         static void SetGaugeFn(IntPtr prometheusPtr, IntPtr name, double value, ref IntPtr labels, UInt32 labelsCount)
         {
             string nameStr = Marshal.PtrToStringAnsi(name);
+            var labelsArr = Marshal.PtrToStructure<string[]>(labels);
             var prometheus = RetrievePrometheus(prometheusPtr);
-            prometheus.SetGauge(nameStr, value);
+            prometheus.SetGauge(nameStr, value, labelsArr);
         }
 
         static void AddGaugeFn(IntPtr prometheusPtr, IntPtr name, double value, ref IntPtr labels, UInt32 labelsCount)

--- a/pitaya-sharp/NPitaya/src/Metrics/PrometheusReporter.cs
+++ b/pitaya-sharp/NPitaya/src/Metrics/PrometheusReporter.cs
@@ -26,10 +26,11 @@ namespace NPitaya.Metrics
         internal PrometheusReporter(MetricsConfiguration config) : this(
             config.Host,
             config.Port,
-            config.Namespace
+            config.Namespace,
+            config.CustomMetrics
         ){}
 
-        private PrometheusReporter(string host, string port, string @namespace)
+        private PrometheusReporter(string host, string port, string @namespace, CustomMetrics customMetrics)
         {
             _namespace = @namespace;
             _host = host;
@@ -46,6 +47,7 @@ namespace NPitaya.Metrics
                 .WithGcStats()
                 .WithExceptionStats();
             _systemMetrics = new ServiceCollection();
+            ImportCustomMetrics(customMetrics);
         }
 
         internal void Start()
@@ -107,6 +109,26 @@ namespace NPitaya.Metrics
         string BuildKey(string suffix)
         {
             return $"{_namespace}{LabelSeparator}{suffix}";
+        }
+
+        void ImportCustomMetrics(CustomMetrics metrics)
+        {
+            if (metrics == null) return;
+
+            foreach (var metric in metrics.Counters)
+            {
+                RegisterCounter(metric.Name, metric.Help, metric.Labels);
+            }
+
+            foreach (var metric in metrics.Gauges)
+            {
+                RegisterGauge(metric.Name, metric.Help, metric.Labels);
+            }
+
+            foreach (var metric in metrics.Histograms)
+            {
+                RegisterHistogram(metric.Name, metric.Help, metric.Labels);
+            }
         }
     }
 }

--- a/pitaya-sharp/NPitaya/src/Metrics/PrometheusReporter.cs
+++ b/pitaya-sharp/NPitaya/src/Metrics/PrometheusReporter.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Security.Authentication.ExtendedProtection;
 using Microsoft.Extensions.DependencyInjection;
@@ -11,7 +12,7 @@ namespace NPitaya.Metrics
     public class PrometheusReporter
     {
         const string LabelSeparator = "_";
-        static readonly string[] NoLabels = new string[] {};
+        static readonly string[] NoLabels = {};
 
         readonly string _host;
         readonly int _port;
@@ -31,7 +32,7 @@ namespace NPitaya.Metrics
             config.CustomMetrics
         ){}
 
-        private PrometheusReporter(string host, string port, string @namespace, CustomMetrics customMetrics)
+        private PrometheusReporter(string host, string port, string @namespace, CustomMetrics? customMetrics)
         {
             _namespace = @namespace;
             _host = host;
@@ -54,36 +55,36 @@ namespace NPitaya.Metrics
         internal void Start()
         {
             Logger.Info("Starting Prometheus metrics server at {0}:{1}", _host, _port);
-            _dotnetCollector?.StartCollecting();
+            _dotnetCollector.StartCollecting();
             _systemMetrics.AddSystemMetrics();
             _server.Start();
         }
 
-        internal void RegisterCounter(string name, string help = null, string[] labels = null)
+        internal void RegisterCounter(string name, string help, string[] labels)
         {
             var key = BuildKey(name);
             Logger.Debug($"Registering counter metric {key}");
-            var counter = Prometheus.Metrics.CreateCounter(key, help ?? "", labels ?? NoLabels);
+            var counter = Prometheus.Metrics.CreateCounter(key, help, labels);
             _counters.Add(key, counter);
         }
 
-        internal void RegisterGauge(string name, string help = null, string[] labels = null)
+        internal void RegisterGauge(string name, string help, string[] labels)
         {
             var key = BuildKey(name);
             Logger.Debug($"Registering gauge metric {key}");
-            var gauge = Prometheus.Metrics.CreateGauge(key, help ?? "", labels ?? NoLabels);
+            var gauge = Prometheus.Metrics.CreateGauge(key, help, labels);
             _gauges.Add(key, gauge);
         }
 
-        internal void RegisterHistogram(string name, string help = null, string[] labels = null)
+        internal void RegisterHistogram(string name, string help, string[] labels)
         {
             var key = BuildKey(name);
             Logger.Debug($"Registering histogram metric {key}");
-            var histogram = Prometheus.Metrics.CreateHistogram(key, help ?? "", labels ?? NoLabels);
+            var histogram = Prometheus.Metrics.CreateHistogram(key, help, labels);
             _histograms.Add(key, histogram);
         }
 
-        internal void IncCounter(string name, string[] labels = null)
+        internal void IncCounter(string name, string[]? labels)
         {
             var key = BuildKey(name);
             var counter = _counters[key];
@@ -91,7 +92,7 @@ namespace NPitaya.Metrics
             counter.WithLabels(labels ?? NoLabels).Inc();
         }
 
-        internal void SetGauge(string name, double value, string[] labels = null)
+        internal void SetGauge(string name, double value, string[]? labels)
         {
             var key = BuildKey(name);
             var gauge = _gauges[key];
@@ -99,7 +100,7 @@ namespace NPitaya.Metrics
             gauge.WithLabels(labels ?? NoLabels).Set(value);
         }
 
-        internal void ObserveHistogram(string name, double value, string[] labels = null)
+        internal void ObserveHistogram(string name, double value, string[]? labels)
         {
             var key = BuildKey(name);
             var histogram = _histograms[key];
@@ -112,7 +113,7 @@ namespace NPitaya.Metrics
             return $"{_namespace}{LabelSeparator}{suffix}";
         }
 
-        void ImportCustomMetrics(CustomMetrics metrics)
+        void ImportCustomMetrics(CustomMetrics? metrics)
         {
             if (metrics == null) return;
 

--- a/pitaya-sharp/NPitaya/src/Metrics/PrometheusReporter.cs
+++ b/pitaya-sharp/NPitaya/src/Metrics/PrometheusReporter.cs
@@ -10,7 +10,8 @@ namespace NPitaya.Metrics
 {
     public class PrometheusReporter
     {
-        private const string LabelSeparator = "_";
+        const string LabelSeparator = "_";
+        static readonly string[] NoLabels = new string[] {};
 
         readonly string _host;
         readonly int _port;
@@ -62,7 +63,7 @@ namespace NPitaya.Metrics
         {
             var key = BuildKey(name);
             Logger.Debug($"Registering counter metric {key}");
-            var counter = Prometheus.Metrics.CreateCounter(key, help ?? "");
+            var counter = Prometheus.Metrics.CreateCounter(key, help ?? "", labels ?? NoLabels);
             _counters.Add(key, counter);
         }
 
@@ -70,7 +71,7 @@ namespace NPitaya.Metrics
         {
             var key = BuildKey(name);
             Logger.Debug($"Registering gauge metric {key}");
-            var gauge = Prometheus.Metrics.CreateGauge(key, help ?? "");
+            var gauge = Prometheus.Metrics.CreateGauge(key, help ?? "", labels ?? NoLabels);
             _gauges.Add(key, gauge);
         }
 
@@ -78,7 +79,7 @@ namespace NPitaya.Metrics
         {
             var key = BuildKey(name);
             Logger.Debug($"Registering histogram metric {key}");
-            var histogram = Prometheus.Metrics.CreateHistogram(key, help ?? "");
+            var histogram = Prometheus.Metrics.CreateHistogram(key, help ?? "", labels ?? NoLabels);
             _histograms.Add(key, histogram);
         }
 
@@ -87,7 +88,7 @@ namespace NPitaya.Metrics
             var key = BuildKey(name);
             var counter = _counters[key];
             Logger.Debug($"Incrementing counter {key}");
-            counter.Inc();
+            counter.WithLabels(labels ?? NoLabels).Inc();
         }
 
         internal void SetGauge(string name, double value, string[] labels = null)
@@ -95,7 +96,7 @@ namespace NPitaya.Metrics
             var key = BuildKey(name);
             var gauge = _gauges[key];
             Logger.Debug($"Setting gauge {key} with value {value}");
-            gauge.Set(value);
+            gauge.WithLabels(labels ?? NoLabels).Set(value);
         }
 
         internal void ObserveHistogram(string name, double value, string[] labels = null)
@@ -103,7 +104,7 @@ namespace NPitaya.Metrics
             var key = BuildKey(name);
             var histogram = _histograms[key];
             Logger.Debug($"Observing histogram {key} with value {value}");
-            histogram.Observe(value);
+            histogram.WithLabels(labels ?? NoLabels).Observe(value);
         }
 
         string BuildKey(string suffix)

--- a/pitaya-sharp/NPitaya/src/PitayaCluster.API.cs
+++ b/pitaya-sharp/NPitaya/src/PitayaCluster.API.cs
@@ -290,6 +290,21 @@ namespace NPitaya
             return Rpc<T>("", route, msg);
         }
 
+        public static void IncCounter(string name)
+        {
+            _metricsReporter.IncCounter(name);
+        }
+
+        public static void SetGauge(string name, float value)
+        {
+            _metricsReporter.SetGauge(name, value);
+        }
+
+        public static void IncCounter(string name, float value)
+        {
+            _metricsReporter.ObserveHistogram(name, value);
+        }
+
         private static void OnServerAddedOrRemovedNativeCb(int serverAdded, IntPtr serverPtr, IntPtr user)
         {
             var pitayaClusterHandle = (GCHandle)user;

--- a/pitaya-sharp/NPitaya/src/PitayaCluster.API.cs
+++ b/pitaya-sharp/NPitaya/src/PitayaCluster.API.cs
@@ -109,9 +109,11 @@ namespace NPitaya
             clusterNotificationCallback = new ClusterNotificationCallbackFunc(ClusterNotificationCallback);
             logFunctionCallback = new LogFunction(LogFunctionCallback);
             var logCtx = GCHandle.Alloc(logFunction, GCHandleType.Normal);
+            var pitayaMetrics = IntPtr.Zero;
             if (metricsConfig.IsEnabled)
             {
                 _metricsReporter = new MetricsReporter(metricsConfig);
+                pitayaMetrics = _metricsReporter.GetPitayaPtr();
             }
 
             IntPtr err = pitaya_initialize_with_nats(
@@ -124,7 +126,7 @@ namespace NPitaya
                 logKind,
                 Marshal.GetFunctionPointerForDelegate(logFunctionCallback),
                 GCHandle.ToIntPtr(logCtx),
-                _metricsReporter?.GetPitayaPtr(),
+                pitayaMetrics,
                 serverInfo.Handle,
                 out pitaya
             );
@@ -290,19 +292,19 @@ namespace NPitaya
             return Rpc<T>("", route, msg);
         }
 
-        public static void IncCounter(string name)
+        public static void IncCounter(string name, string[]? labels = null)
         {
-            _metricsReporter.IncCounter(name);
+            _metricsReporter?.IncCounter(name, labels);
         }
 
-        public static void SetGauge(string name, float value)
+        public static void SetGauge(string name, float value, string[]? labels = null)
         {
-            _metricsReporter.SetGauge(name, value);
+            _metricsReporter?.SetGauge(name, value, labels);
         }
 
-        public static void IncCounter(string name, float value)
+        public static void IncCounter(string name, float value, string[]? labels = null)
         {
-            _metricsReporter.ObserveHistogram(name, value);
+            _metricsReporter?.ObserveHistogram(name, value, labels);
         }
 
         private static void OnServerAddedOrRemovedNativeCb(int serverAdded, IntPtr serverPtr, IntPtr user)

--- a/pitaya-sharp/NPitaya/src/PitayaCluster.Native.cs
+++ b/pitaya-sharp/NPitaya/src/PitayaCluster.Native.cs
@@ -39,13 +39,13 @@ namespace NPitaya
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void RegisterGaugeFn(IntPtr userData, MetricsOpts opts);
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate void IncCounterFn(IntPtr userData, IntPtr name, ref IntPtr labels, UInt32 labelsCount);
+        internal delegate void IncCounterFn(IntPtr userData, IntPtr name, IntPtr labels, UInt32 labelsCount);
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate void ObserveHistFn(IntPtr userData, IntPtr name, double value, ref IntPtr labels, UInt32 labelsCount);
+        internal delegate void ObserveHistFn(IntPtr userData, IntPtr name, double value, IntPtr labels, UInt32 labelsCount);
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate void SetGaugeFn(IntPtr userData, IntPtr name, double value, ref IntPtr labels, UInt32 labelsCount);
+        internal delegate void SetGaugeFn(IntPtr userData, IntPtr name, double value, IntPtr labels, UInt32 labelsCount);
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate void AddGaugeFn(IntPtr userData, IntPtr name, double value, ref IntPtr labels, UInt32 labelsCount);
+        internal delegate void AddGaugeFn(IntPtr userData, IntPtr name, double value, IntPtr labels, UInt32 labelsCount);
 
         private const string LibName = "libpitaya";
 

--- a/pitaya-sharp/NPitaya/src/PitayaCluster.Native.cs
+++ b/pitaya-sharp/NPitaya/src/PitayaCluster.Native.cs
@@ -63,7 +63,7 @@ namespace NPitaya
             NativeLogKind logKind,
             IntPtr logFunction,
             IntPtr logCtx,
-            IntPtr? rawMetricsReporter,
+            IntPtr rawMetricsReporter,
             IntPtr serverInfo,
             out IntPtr pitaya);
         [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]

--- a/pitaya-sharp/exampleapp/Program.cs
+++ b/pitaya-sharp/exampleapp/Program.cs
@@ -28,11 +28,7 @@ namespace PitayaCSharpExample
                 PitayaCluster.Terminate();
             };
 
-            var metricsParameters = new MetricsConfiguration(
-                "localhost",
-                "8000",
-                "exampleapp"
-            );
+            var metricsParameters = new MetricsConfiguration(true, "127.0.0.1", "8000", "myns", null);
 
             try
             {

--- a/pitaya-sharp/exampleapp/exampleapp.csproj
+++ b/pitaya-sharp/exampleapp/exampleapp.csproj
@@ -6,13 +6,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <!-- <ProjectReference Include="..\NPitaya\NPitaya.csproj" /> -->
-        <PackageReference Include="NPitaya" Version="0.13.1" />
+        <ProjectReference Include="..\NPitaya\NPitaya.csproj" />
+        <!-- <PackageReference Include="NPitaya" Version="0.13.1" /> -->
     </ItemGroup>
 
-    <!-- <Target Name="PreBuild" BeforeTargets="PreBuildEvent"> -->
-    <!-- <Exec Condition=" '$(OS)' == 'Unix' " Command="&#xA;              LINK_FILE=$(ProjectDir)$(OutDir)/libpitaya.dylib&#xA;              if [[ ! -f $LINK_FILE ]]; then&#xA;                  ln -s $(ProjectDir)../../target/debug/libpitaya.dylib $LINK_FILE&#xA;              fi&#xA;            " /> -->
-    <!-- </Target> -->
+    <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+      <Exec Condition=" '$(OS)' == 'Unix' " Command="&#xA;              LINK_FILE=$(ProjectDir)$(OutDir)/libpitaya.dylib&#xA;              if [[ ! -f $LINK_FILE ]]; then&#xA;                  ln -s $(ProjectDir)../../target/debug/libpitaya.dylib $LINK_FILE&#xA;              fi&#xA;            " />
+    </Target>
 
     <PropertyGroup>
         <RestoreSources>$(RestoreSources);../NPitaya/bin/Release;https://api.nuget.org/v3/index.json</RestoreSources>

--- a/src/pitaya/src/ffi/metrics.rs
+++ b/src/pitaya/src/ffi/metrics.rs
@@ -73,7 +73,8 @@ fn generic_register(
         .iter()
         .map(|l| CString::new(l.as_str()).expect("string should be valid"))
         .collect();
-    let mut variable_labels_ptr: Vec<*const c_char> = variable_labels.iter().map(|s| s.as_ptr()).collect();
+    let mut variable_labels_ptr: Vec<*const c_char> =
+        variable_labels.iter().map(|s| s.as_ptr()).collect();
 
     // These options will be passed to C#.
     // We cannot simply get a raw pointer to the &str, since C expects

--- a/src/pitaya/src/ffi/metrics.rs
+++ b/src/pitaya/src/ffi/metrics.rs
@@ -68,11 +68,12 @@ fn generic_register(
     // TODO(lhahn): this function allocates a lot of unnecessary memory.
     // consider improving this in the future.
 
-    let variable_labels = opts
+    let variable_labels: Vec<CString> = opts
         .variable_labels
         .iter()
-        .map(|l| CString::new(l.as_str()).expect("string should be valid"));
-    let mut variable_labels_ptr: Vec<*const c_char> = variable_labels.map(|s| s.as_ptr()).collect();
+        .map(|l| CString::new(l.as_str()).expect("string should be valid"))
+        .collect();
+    let mut variable_labels_ptr: Vec<*const c_char> = variable_labels.iter().map(|s| s.as_ptr()).collect();
 
     // These options will be passed to C#.
     // We cannot simply get a raw pointer to the &str, since C expects
@@ -132,11 +133,11 @@ impl crate::metrics::Reporter for PitayaMetricsReporter {
     }
 
     fn inc_counter(&self, name: &str, labels: &[&str]) -> Result<(), crate::metrics::Error> {
-        let labels = labels
+        let labels: Vec<CString> = labels
             .iter()
-            .map(|l| CString::new(*l).expect("string should be valid"));
-        let mut labels_ptr: Vec<*const c_char> =
-            labels.map(|s| s.as_ptr() as *const c_char).collect();
+            .map(|l| CString::new(*l).expect("string should be valid"))
+            .collect();
+        let mut labels_ptr: Vec<*const c_char> = labels.iter().map(|s| s.as_ptr()).collect();
         let name = CString::new(name).expect("string in rust should be valid");
 
         (self.inc_counter_fn)(
@@ -155,11 +156,11 @@ impl crate::metrics::Reporter for PitayaMetricsReporter {
         value: f64,
         labels: &[&str],
     ) -> Result<(), crate::metrics::Error> {
-        let labels = labels
+        let labels: Vec<CString> = labels
             .iter()
-            .map(|l| CString::new(*l).expect("string should be valid"));
-        let mut labels_ptr: Vec<*const c_char> =
-            labels.map(|s| s.as_ptr() as *const c_char).collect();
+            .map(|l| CString::new(*l).expect("string should be valid"))
+            .collect();
+        let mut labels_ptr: Vec<*const c_char> = labels.iter().map(|s| s.as_ptr()).collect();
         let name = CString::new(name).expect("string in rust should be valid");
 
         (self.observe_hist_fn)(
@@ -179,10 +180,11 @@ impl crate::metrics::Reporter for PitayaMetricsReporter {
         value: f64,
         labels: &[&str],
     ) -> Result<(), crate::metrics::Error> {
-        let labels = labels
+        let labels: Vec<CString> = labels
             .iter()
-            .map(|l| CString::new(*l).expect("string should be valid"));
-        let mut labels_ptr: Vec<*const c_char> = labels.map(|s| s.as_ptr()).collect();
+            .map(|l| CString::new(*l).expect("string should be valid"))
+            .collect();
+        let mut labels_ptr: Vec<*const c_char> = labels.iter().map(|s| s.as_ptr()).collect();
         let name = CString::new(name).expect("string in rust should be valid");
 
         (self.set_gauge_fn)(
@@ -202,11 +204,11 @@ impl crate::metrics::Reporter for PitayaMetricsReporter {
         value: f64,
         labels: &[&str],
     ) -> Result<(), crate::metrics::Error> {
-        let labels = labels
+        let labels: Vec<CString> = labels
             .iter()
-            .map(|l| CString::new(*l).expect("string should be valid"));
-        let mut labels_ptr: Vec<*const c_char> =
-            labels.map(|s| s.as_ptr() as *const c_char).collect();
+            .map(|l| CString::new(*l).expect("string should be valid"))
+            .collect();
+        let mut labels_ptr: Vec<*const c_char> = labels.iter().map(|s| s.as_ptr()).collect();
         let name = CString::new(name).expect("string in rust should be valid");
 
         (self.add_gauge_fn)(


### PR DESCRIPTION
In this PR, we are adding custom metrics, through metrics configuration struct and also support for metrics labels. We are also adding the label support to Pitaya internal metrics.

Finally, this PR created version 0.14.0, with Prometheus metrics fully integrated on C# level.