### PR TITLE
feat: more pitaya metrics

### DIFF
--- a/src/pitaya/src/lib.rs
+++ b/src/pitaya/src/lib.rs
@@ -647,6 +647,7 @@ impl<'a> PitayaBuilder<'a> {
             logger.clone(),
             nats_settings,
             server_info.clone(),
+            metrics_reporter.clone(),
         )));
 
         let rpc_dispatch = if let Some(rpc_handler) = self.rpc_handler {

--- a/src/pitaya_core/src/metrics.rs
+++ b/src/pitaya_core/src/metrics.rs
@@ -133,16 +133,31 @@ pub fn exponential_buckets(start: f64, factor: f64, count: usize) -> Vec<f64> {
     buckets
 }
 
-pub async fn record_histogram_duration(
+pub async fn record_histogram_duration<'a>(
+    logger: slog::Logger,
     reporter: ThreadSafeReporter,
-    name: &str,
+    name: &'a str,
     start: std::time::Instant,
-    labels: &[&str],
+    labels: &'a [&'a str],
 ) {
     let elapsed = std::time::Instant::now() - start;
-    reporter
+    if let Err(e) = reporter
         .read()
         .await
         .observe_hist(name, elapsed.as_secs_f64(), labels)
-        .expect("should not fail to observe");
+    {
+        slog::warn!(logger, "observe_hist failed"; "err" => %e);
+    }
+}
+
+pub async fn add_gauge<'a>(
+    logger: slog::Logger,
+    reporter: ThreadSafeReporter,
+    name: &'a str,
+    value: f64,
+    labels: &'a [&'a str],
+) {
+    if let Err(e) = reporter.read().await.add_gauge(name, value, labels) {
+        slog::warn!(logger, "add_gauge failed"; "err" => %e);
+    }
 }

--- a/src/pitaya_core/src/metrics.rs
+++ b/src/pitaya_core/src/metrics.rs
@@ -150,7 +150,7 @@ pub async fn record_histogram_duration<'a>(
     }
 }
 
-pub async fn add_gauge<'a>(
+pub async fn add_to_gauge<'a>(
     logger: slog::Logger,
     reporter: ThreadSafeReporter,
     name: &'a str,

--- a/src/pitaya_core/src/service.rs
+++ b/src/pitaya_core/src/service.rs
@@ -189,7 +189,7 @@ impl Remote {
         };
 
         if response.error.is_some() {
-            error!(logger, "handler returning error for RPC");
+            warn!(logger, "handler returning error for RPC");
         }
 
         if !rpc.respond(response) {

--- a/src/pitaya_etcd_nats_cluster/src/rpc_client.rs
+++ b/src/pitaya_etcd_nats_cluster/src/rpc_client.rs
@@ -300,7 +300,6 @@ mod tests {
 
     #[tokio::test]
     async fn nats_request_timeout() -> Result<(), Error> {
-        let reporter = Arc::new(RwLock::new(Box::new(metrics::DummyReporter {})));
         let client = NatsRpcClient::new(
             test_helpers::get_root_logger(),
             Arc::new(settings::Nats {

--- a/src/pitaya_etcd_nats_cluster/src/rpc_server.rs
+++ b/src/pitaya_etcd_nats_cluster/src/rpc_server.rs
@@ -172,6 +172,9 @@ impl NatsRpcServer {
         rpc_start: Instant,
         success: bool,
     ) {
+        // TODO(lhahn): we're unnecessarily locking the same mutex on the reporter two times.
+        // We should consider changing this if it becomes a problem in the future.
+
         metrics::record_histogram_duration(
             logger.clone(),
             reporter.clone(),

--- a/src/pitaya_etcd_nats_cluster/src/rpc_server.rs
+++ b/src/pitaya_etcd_nats_cluster/src/rpc_server.rs
@@ -155,7 +155,7 @@ impl NatsRpcServer {
     }
 
     async fn record_rpc_start(logger: slog::Logger, reporter: metrics::ThreadSafeReporter) {
-        metrics::add_gauge(
+        metrics::add_to_gauge(
             logger.clone(),
             reporter.clone(),
             RPCS_IN_FLIGHT_METRIC,
@@ -184,7 +184,7 @@ impl NatsRpcServer {
         )
         .await;
 
-        metrics::add_gauge(logger, reporter, RPCS_IN_FLIGHT_METRIC, -1.0, &[]).await;
+        metrics::add_to_gauge(logger, reporter, RPCS_IN_FLIGHT_METRIC, -1.0, &[]).await;
     }
 
     fn respond(


### PR DESCRIPTION
This commit add more metrics to pitaya, particularly latency for client
RPCs and also the number of RPCs in flight currently on the server.