### PR TITLE
Fix NATS authenticated connection support

### DIFF
--- a/pitaya-sharp/NPitaya/NPitaya.csproj
+++ b/pitaya-sharp/NPitaya/NPitaya.csproj
@@ -4,7 +4,7 @@
     <PropertyGroup>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <PackageId>NPitaya</PackageId>
-        <PackageVersion>0.15.0</PackageVersion>
+        <PackageVersion>0.15.1</PackageVersion>
         <Title>NPitaya</Title>
         <Authors>TFG Co</Authors>
         <Description>A full implementation of pitaya backend framework for .NET</Description>

--- a/src/pitaya/src/lib.rs
+++ b/src/pitaya/src/lib.rs
@@ -310,7 +310,7 @@ impl Pitaya {
         // sure that the server is set up.
         self.discovery.lock().await.start(app_die_sender).await?;
 
-        info!(self.logger, "finshed starting pitaya server");
+        info!(self.logger, "finished starting pitaya server");
         Ok(graceful_shutdown_receiver)
     }
 

--- a/src/pitaya_etcd_nats_cluster/Cargo.toml
+++ b/src/pitaya_etcd_nats_cluster/Cargo.toml
@@ -13,7 +13,7 @@ tokio = { version = "0.2", features = ["full"] }
 async-trait = "0.1"
 serde = "1.0"
 serde_json = "1.0"
-nats = "0.5"
+nats = "0.8.2"
 etcd-client = "0.2"
 slog = { version = "2.5", features = ["max_level_trace"] }
 humantime-serde = "1.0"

--- a/src/pitaya_etcd_nats_cluster/src/constants.rs
+++ b/src/pitaya_etcd_nats_cluster/src/constants.rs
@@ -10,3 +10,5 @@ pub const DEFAULT_NATS_CONN_TIMEOUT: Duration = Duration::from_secs(5);
 pub const DEFAULT_NATS_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 pub const DEFAULT_NATS_MAX_RECONN_ATTEMPTS: u32 = 5;
 pub const DEFAULT_NATS_MAX_RPCS_QUEUED: u32 = 100;
+pub const DEFAULT_NATS_AUTH_USER: &str = "";
+pub const DEFAULT_NATS_AUTH_PASS: &str = "";

--- a/src/pitaya_etcd_nats_cluster/src/rpc_client.rs
+++ b/src/pitaya_etcd_nats_cluster/src/rpc_client.rs
@@ -62,7 +62,8 @@ impl RpcClient for NatsRpcClient {
         self.register_metrics().await;
 
         info!(self.logger, "client connecting to nats"; "url" => &self.settings.url);
-        let nc = nats::ConnectionOptions::new()
+        let nc = nats::ConnectionOptions
+            ::with_user_pass(&self.settings.auth_user, &self.settings.auth_pass)
             .max_reconnects(Some(self.settings.max_reconnection_attempts as usize))
             .connect(&self.settings.url)
             .map_err(Error::Nats)?;

--- a/src/pitaya_etcd_nats_cluster/src/rpc_client.rs
+++ b/src/pitaya_etcd_nats_cluster/src/rpc_client.rs
@@ -62,13 +62,10 @@ impl RpcClient for NatsRpcClient {
         self.register_metrics().await;
 
         info!(self.logger, "client connecting to nats"; "url" => &self.settings.url);
-        let nc = nats::ConnectionOptions::with_user_pass(
-            &self.settings.auth_user,
-            &self.settings.auth_pass,
-        )
-        .max_reconnects(Some(self.settings.max_reconnection_attempts as usize))
-        .connect(&self.settings.url)
-        .map_err(Error::Nats)?;
+        let nc = nats::Options::with_user_pass(&self.settings.auth_user, &self.settings.auth_pass)
+            .max_reconnects(Some(self.settings.max_reconnection_attempts as usize))
+            .connect(&self.settings.url)
+            .map_err(Error::Nats)?;
 
         self.connection.write().await.replace(nc);
 

--- a/src/pitaya_etcd_nats_cluster/src/rpc_client.rs
+++ b/src/pitaya_etcd_nats_cluster/src/rpc_client.rs
@@ -62,11 +62,13 @@ impl RpcClient for NatsRpcClient {
         self.register_metrics().await;
 
         info!(self.logger, "client connecting to nats"; "url" => &self.settings.url);
-        let nc = nats::ConnectionOptions
-            ::with_user_pass(&self.settings.auth_user, &self.settings.auth_pass)
-            .max_reconnects(Some(self.settings.max_reconnection_attempts as usize))
-            .connect(&self.settings.url)
-            .map_err(Error::Nats)?;
+        let nc = nats::ConnectionOptions::with_user_pass(
+            &self.settings.auth_user,
+            &self.settings.auth_pass,
+        )
+        .max_reconnects(Some(self.settings.max_reconnection_attempts as usize))
+        .connect(&self.settings.url)
+        .map_err(Error::Nats)?;
 
         self.connection.write().await.replace(nc);
 

--- a/src/pitaya_etcd_nats_cluster/src/rpc_server.rs
+++ b/src/pitaya_etcd_nats_cluster/src/rpc_server.rs
@@ -241,13 +241,11 @@ impl RpcServer for NatsRpcServer {
 
         // TODO(lhahn): add callbacks here for sending metrics.
         info!(self.logger, "server connecting to nats"; "url" => &self.settings.url);
-        let nats_connection = nats::ConnectionOptions::with_user_pass(
-            &self.settings.auth_user,
-            &self.settings.auth_pass,
-        )
-        .max_reconnects(Some(self.settings.max_reconnection_attempts as usize))
-        .connect(&self.settings.url)
-        .map_err(Error::Nats)?;
+        let nats_connection =
+            nats::Options::with_user_pass(&self.settings.auth_user, &self.settings.auth_pass)
+                .max_reconnects(Some(self.settings.max_reconnection_attempts as usize))
+                .connect(&self.settings.url)
+                .map_err(Error::Nats)?;
 
         let (rpc_sender, rpc_receiver) = mpsc::channel(self.settings.max_rpcs_queued as usize);
 

--- a/src/pitaya_etcd_nats_cluster/src/rpc_server.rs
+++ b/src/pitaya_etcd_nats_cluster/src/rpc_server.rs
@@ -241,11 +241,13 @@ impl RpcServer for NatsRpcServer {
 
         // TODO(lhahn): add callbacks here for sending metrics.
         info!(self.logger, "server connecting to nats"; "url" => &self.settings.url);
-        let nats_connection = nats::ConnectionOptions
-            ::with_user_pass(&self.settings.auth_user, &self.settings.auth_pass)
-            .max_reconnects(Some(self.settings.max_reconnection_attempts as usize))
-            .connect(&self.settings.url)
-            .map_err(Error::Nats)?;
+        let nats_connection = nats::ConnectionOptions::with_user_pass(
+            &self.settings.auth_user,
+            &self.settings.auth_pass,
+        )
+        .max_reconnects(Some(self.settings.max_reconnection_attempts as usize))
+        .connect(&self.settings.url)
+        .map_err(Error::Nats)?;
 
         let (rpc_sender, rpc_receiver) = mpsc::channel(self.settings.max_rpcs_queued as usize);
 

--- a/src/pitaya_etcd_nats_cluster/src/rpc_server.rs
+++ b/src/pitaya_etcd_nats_cluster/src/rpc_server.rs
@@ -241,7 +241,8 @@ impl RpcServer for NatsRpcServer {
 
         // TODO(lhahn): add callbacks here for sending metrics.
         info!(self.logger, "server connecting to nats"; "url" => &self.settings.url);
-        let nats_connection = nats::ConnectionOptions::new()
+        let nats_connection = nats::ConnectionOptions
+            ::with_user_pass(&self.settings.auth_user, &self.settings.auth_pass)
             .max_reconnects(Some(self.settings.max_reconnection_attempts as usize))
             .connect(&self.settings.url)
             .map_err(Error::Nats)?;

--- a/src/pitaya_etcd_nats_cluster/src/settings.rs
+++ b/src/pitaya_etcd_nats_cluster/src/settings.rs
@@ -15,10 +15,10 @@ pub struct Nats {
     #[serde(with = "humantime_serde")]
     pub request_timeout: Duration,
 
-    // The maximum amount of times the nats client will atempt to reconnect.
+    // The maximum amount of times the nats client will attempt to reconnect.
     pub max_reconnection_attempts: u32,
 
-    // The maximum amount of rpcs queued that a nats server will have.
+    // The maximum amount of RPCs queued that a nats server will have.
     // If this amount is passed, RPCs will fail.
     pub max_rpcs_queued: u32,
 
@@ -49,7 +49,7 @@ pub struct Etcd {
     pub url: String,
 
     // The prefix where all keys are going to be stored in ETCD.
-    // This will tipically be the name of your app.
+    // This will typically be the name of your app.
     pub prefix: String,
 
     // How long should the lease TTL be for this server.

--- a/src/pitaya_etcd_nats_cluster/src/settings.rs
+++ b/src/pitaya_etcd_nats_cluster/src/settings.rs
@@ -22,7 +22,7 @@ pub struct Nats {
     // If this amount is passed, RPCs will fail.
     pub max_rpcs_queued: u32,
 
-    // The NATS connection username. 
+    // The NATS connection username.
     pub auth_user: String,
 
     // The NATS connection password.
@@ -38,7 +38,7 @@ impl Default for Nats {
             max_reconnection_attempts: constants::DEFAULT_NATS_MAX_RECONN_ATTEMPTS,
             max_rpcs_queued: constants::DEFAULT_NATS_MAX_RPCS_QUEUED,
             auth_user: constants::DEFAULT_NATS_AUTH_USER.to_owned(),
-            auth_pass: constants::DEFAULT_NATS_AUTH_PASS.to_owned()
+            auth_pass: constants::DEFAULT_NATS_AUTH_PASS.to_owned(),
         }
     }
 }

--- a/src/pitaya_etcd_nats_cluster/src/settings.rs
+++ b/src/pitaya_etcd_nats_cluster/src/settings.rs
@@ -21,6 +21,12 @@ pub struct Nats {
     // The maximum amount of rpcs queued that a nats server will have.
     // If this amount is passed, RPCs will fail.
     pub max_rpcs_queued: u32,
+
+    // The NATS connection username. 
+    pub auth_user: String,
+
+    // The NATS connection password.
+    pub auth_pass: String,
 }
 
 impl Default for Nats {
@@ -31,6 +37,8 @@ impl Default for Nats {
             request_timeout: constants::DEFAULT_NATS_REQUEST_TIMEOUT,
             max_reconnection_attempts: constants::DEFAULT_NATS_MAX_RECONN_ATTEMPTS,
             max_rpcs_queued: constants::DEFAULT_NATS_MAX_RPCS_QUEUED,
+            auth_user: constants::DEFAULT_NATS_AUTH_USER.to_owned(),
+            auth_pass: constants::DEFAULT_NATS_AUTH_PASS.to_owned()
         }
     }
 }


### PR DESCRIPTION
In this PR, we add NATS user/pass authentication parameters to Pitaya configurations, in order to the NATS module proper connect to a protected NATS cluster.