### PR TITLE
Use Protobuf for internal RPC communication

### DIFF
--- a/pitaya-sharp/NPitaya/NPitaya.csproj
+++ b/pitaya-sharp/NPitaya/NPitaya.csproj
@@ -4,7 +4,7 @@
     <PropertyGroup>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <PackageId>NPitaya</PackageId>
-        <PackageVersion>0.15.3</PackageVersion>
+        <PackageVersion>0.16.0</PackageVersion>
         <Title>NPitaya</Title>
         <Authors>TFG Co</Authors>
         <Description>A full implementation of pitaya backend framework for .NET</Description>

--- a/pitaya-sharp/NPitaya/NPitaya.csproj
+++ b/pitaya-sharp/NPitaya/NPitaya.csproj
@@ -21,7 +21,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Google.Protobuf" Version="3.7.0" />
+        <PackageReference Include="Google.Protobuf" Version="3.13.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.9" />
         <PackageReference Include="prometheus-net" Version="4.0.0" />
         <PackageReference Include="prometheus-net.DotNetRuntime" Version="3.4.0" />

--- a/pitaya-sharp/NPitaya/src/Models/PitayaSession.cs
+++ b/pitaya-sharp/NPitaya/src/Models/PitayaSession.cs
@@ -3,8 +3,8 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Google.Protobuf;
 using NPitaya.Constants;
-using Json = PitayaSimpleJson.SimpleJson;
 using NPitaya.Protos;
+using Json = PitayaSimpleJson.SimpleJson;
 
 namespace NPitaya.Models
 {
@@ -16,19 +16,19 @@ namespace NPitaya.Models
         string _rawData;
         public string RawData => _rawData;
         public string Uid { get; private set; }
-        RpcClient _rpcClient;
+        readonly RpcClient _rpcClient;
 
-        internal PitayaSession(Protos.Session sessionProto, RpcClient rpcClient)
+        internal PitayaSession(Session sessionProto, RpcClient rpcClient)
         {
             _rpcClient = rpcClient;
             _id = sessionProto.Id;
             Uid = sessionProto.Uid;
             _rawData = sessionProto.Data.ToStringUtf8();
-            if (!String.IsNullOrEmpty(_rawData))
+            if (!string.IsNullOrEmpty(_rawData))
                 _data = Json.DeserializeObject<Dictionary<string, object>>(_rawData);
         }
 
-        internal PitayaSession(Protos.Session sessionProto, RpcClient rpcClient, string frontendId)
+        internal PitayaSession(Session sessionProto, RpcClient rpcClient, string frontendId)
             : this(sessionProto, rpcClient)
         {
             _frontendId = frontendId;
@@ -74,7 +74,7 @@ namespace NPitaya.Models
 
         public Task PushToFrontend()
         {
-            if (String.IsNullOrEmpty(_frontendId))
+            if (string.IsNullOrEmpty(_frontendId))
             {
                 return Task.FromException(new Exception("cannot push to frontend, frontendId is invalid!"));
             }
@@ -134,7 +134,7 @@ namespace NPitaya.Models
 
         Task SendRequestToFront(string route, bool includeData)
         {
-            var sessionProto = new Protos.Session
+            var sessionProto = new Session
             {
                 Id = _id,
                 Uid = Uid

--- a/pitaya-sharp/NPitaya/src/PitayaCluster.API.cs
+++ b/pitaya-sharp/NPitaya/src/PitayaCluster.API.cs
@@ -19,6 +19,7 @@ namespace NPitaya
     public partial class PitayaCluster
     {
         private static ISerializer _serializer = new JSONSerializer();
+        static ProtobufSerializer _remoteSerializer = new ProtobufSerializer();
         public delegate string RemoteNameFunc(string methodName);
         delegate void OnSignalFunc();
         static readonly Dictionary<string, RemoteMethod> RemotesDict = new Dictionary<string, RemoteMethod>();

--- a/pitaya-sharp/NPitaya/src/PitayaCluster.API.cs
+++ b/pitaya-sharp/NPitaya/src/PitayaCluster.API.cs
@@ -282,12 +282,12 @@ namespace NPitaya
             return _rpcClient.SendKickToUser(frontendId, serverKind, kick);
         }
 
-        public static Task<T> Rpc<T>(string serverId, Route route, object msg)
+        public static Task<T> Rpc<T>(string serverId, Route route, IMessage msg)
         {
             return _rpcClient.Rpc<T>(serverId, route, msg);
         }
 
-        public static Task<T> Rpc<T>(Route route, object msg)
+        public static Task<T> Rpc<T>(Route route, IMessage msg)
         {
             return Rpc<T>("", route, msg);
         }

--- a/pitaya-sharp/NPitaya/src/PitayaCluster.RPC.cs
+++ b/pitaya-sharp/NPitaya/src/PitayaCluster.RPC.cs
@@ -48,7 +48,7 @@ namespace NPitaya
             Task ans;
             if (handler.ArgType != null)
             {
-                var arg = _serializer.Unmarshal(data, handler.ArgType);
+                var arg = Unmarshal(data, handler.ArgType, req.FrontendID);
                 if (type == RPCType.Sys)
                     ans = handler.Method.Invoke(handler.Obj, new[] {s, arg}) as Task;
                 else
@@ -77,6 +77,16 @@ namespace NPitaya
             }
             response.Data = ByteString.CopyFrom(ansBytes);
             return response;
+        }
+
+        static object Unmarshal(byte[] data, Type type, string frontendId)
+        {
+            if (string.IsNullOrEmpty(frontendId))
+            {
+                return _remoteSerializer.Unmarshal(data, type);
+            }
+
+            return _serializer.Unmarshal(data, type);
         }
 
         static void DispatchRpc(RpcClient rpcClient, IntPtr rpc, Protos.Request req)

--- a/pitaya-sharp/NPitaya/src/PitayaCluster.RPC.cs
+++ b/pitaya-sharp/NPitaya/src/PitayaCluster.RPC.cs
@@ -13,7 +13,7 @@ namespace NPitaya
         static async Task<Response> HandleRpc(RpcClient rpcClient, Protos.Request req, RPCType type)
         {
             byte[] data = req.Msg.Data.ToByteArray();
-            Route route = Route.FromString(req.Msg.Route);
+            var route = Route.FromString(req.Msg.Route);
 
             string handlerName = $"{route.service}.{route.method}";
 
@@ -23,7 +23,7 @@ namespace NPitaya
             RemoteMethod handler;
             if (type == RPCType.Sys)
             {
-                s = new Models.PitayaSession(req.Session, rpcClient, req.FrontendID);
+                s = new PitayaSession(req.Session, rpcClient, req.FrontendID);
                 if (!HandlersDict.ContainsKey(handlerName))
                 {
                     response = GetErrorResponse("PIT-404",

--- a/pitaya-sharp/NPitaya/src/PitayaCluster.RPC.cs
+++ b/pitaya-sharp/NPitaya/src/PitayaCluster.RPC.cs
@@ -67,9 +67,18 @@ namespace NPitaya
 
             if (handler.ReturnType != typeof(void))
             {
+                ISerializer serializer;
+                if (req.Type == RPCType.Sys)
+                {
+                    serializer = _serializer;
+                }
+                else
+                {
+                    serializer = _remoteSerializer;
+                }
                 ansBytes = SerializerUtils.SerializeOrRaw(ans.GetType().
                     GetProperty("Result")
-                    ?.GetValue(ans), _serializer);
+                    ?.GetValue(ans), serializer);
             }
             else
             {

--- a/pitaya-sharp/NPitaya/src/RpcClient.cs
+++ b/pitaya-sharp/NPitaya/src/RpcClient.cs
@@ -12,16 +12,40 @@ namespace NPitaya
     // RpcClient allows sending RPC messages to other Pitaya servers.
     internal class RpcClient
     {
-        IntPtr _pitaya;
-        ISerializer _serializer;
+        readonly IntPtr _pitaya;
+        readonly ISerializer _serializer;
+        readonly ProtobufSerializer _internalRpcSerializer;
 
         public RpcClient(IntPtr pitaya, ISerializer serializer)
         {
             _pitaya = pitaya;
             _serializer = serializer;
+            _internalRpcSerializer = BuildInterRpcSerializer(serializer);
+        }
+
+        static ProtobufSerializer BuildInterRpcSerializer(ISerializer receivedSerializer)
+        {
+            if (receivedSerializer.GetType() == typeof(ProtobufSerializer))
+            {
+                return (ProtobufSerializer) receivedSerializer;
+            }
+
+            return new ProtobufSerializer();
         }
 
         public Task<T> Rpc<T>(string serverId, Route route, object msg)
+        {
+            var payload = SerializerUtils.SerializeOrRaw(msg, _serializer);
+            return DoRpc<T>(serverId, route, payload);
+        }
+
+        internal Task<T> Rpc<T>(string serverId, Route route, IMessage msg)
+        {
+            var payload = SerializerUtils.SerializeOrRaw(msg, _internalRpcSerializer);
+            return DoRpc<T>(serverId, route, payload);
+        }
+
+        Task<T> DoRpc<T>(string serverId, Route route, byte[] payload)
         {
             return Task.Run(() =>
             {
@@ -35,10 +59,9 @@ namespace NPitaya
 
                 unsafe
                 {
-                    var data = SerializerUtils.SerializeOrRaw(msg, _serializer);
-                    fixed (byte* p = data)
+                    fixed (byte* p = payload)
                     {
-                        IntPtr request = PitayaCluster.pitaya_buffer_new((IntPtr)p, data.Length);
+                        IntPtr request = PitayaCluster.pitaya_buffer_new((IntPtr)p, payload.Length);
                         PitayaCluster.pitaya_send_rpc(
                             _pitaya,
                             serverId,

--- a/pitaya-sharp/NPitaya/src/RpcClient.cs
+++ b/pitaya-sharp/NPitaya/src/RpcClient.cs
@@ -35,17 +35,15 @@ namespace NPitaya
 
         public Task<T> Rpc<T>(string serverId, Route route, object msg)
         {
-            var payload = SerializerUtils.SerializeOrRaw(msg, _serializer);
-            return DoRpc<T>(serverId, route, payload);
+            return DoRpc<T>(serverId, route, msg, _serializer);
         }
 
         internal Task<T> Rpc<T>(string serverId, Route route, IMessage msg)
         {
-            var payload = SerializerUtils.SerializeOrRaw(msg, _internalRpcSerializer);
-            return DoRpc<T>(serverId, route, payload);
+            return DoRpc<T>(serverId, route, msg, _internalRpcSerializer);
         }
 
-        Task<T> DoRpc<T>(string serverId, Route route, byte[] payload)
+        Task<T> DoRpc<T>(string serverId, Route route, object msg, ISerializer serializer)
         {
             return Task.Run(() =>
             {
@@ -53,9 +51,10 @@ namespace NPitaya
                 var context = new CallbackContext<T>
                 {
                     t = new TaskCompletionSource<T>(),
-                    serializer = _serializer,
+                    serializer = serializer,
                 };
                 var handle = GCHandle.Alloc(context, GCHandleType.Normal);
+                var payload = SerializerUtils.SerializeOrRaw(msg, serializer);
 
                 unsafe
                 {

--- a/pitaya-sharp/exampleapp/Program.cs
+++ b/pitaya-sharp/exampleapp/Program.cs
@@ -28,19 +28,19 @@ namespace PitayaCSharpExample
                 PitayaCluster.Terminate();
             };
 
-            var metricsParameters = new MetricsConfiguration(true, "127.0.0.1", "8000", "myns", null);
+            var metricsParameters = new MetricsConfiguration(false, "127.0.0.1", "8000", "myns", null);
 
             try
             {
                 PitayaCluster.Initialize(
-                    "CSHARP",
+                    "exampleapp",
                     "csharp.toml",
                     new Server(
-                        id: "c#-id",
-                        kind: "random-server-kind",
+                        id: Guid.NewGuid().ToString(),
+                        kind: "csharp",
                         metadata: "{}",
                         hostname: "ololo",
-                        frontend: true
+                        frontend: false
                     ),
                     NativeLogLevel.Debug,
                     NativeLogKind.Console,
@@ -79,7 +79,7 @@ namespace PitayaCSharpExample
             PitayaCluster.RegisterRemote(new TestRemote());
             PitayaCluster.RegisterHandler(new TestHandler());
 
-            // TrySendRpc();
+            TrySendRpc();
 
             PitayaCluster.WaitShutdownSignal();
         }
@@ -97,7 +97,6 @@ namespace PitayaCSharpExample
                         Msg = "HEY",
                     }
                 );
-                // var res = await PitayaCluster.Rpc<NPitaya.Protos.MyResponse>(Route.FromString("room.room.join"), null);
                 Console.WriteLine("GOT MESSAGE!!!");
                 Console.WriteLine($"Code: {res.Code}");
                 Console.WriteLine($"Msg: {res.Msg}");

--- a/pitaya-sharp/exampleapp/remotes/TestRemote.cs
+++ b/pitaya-sharp/exampleapp/remotes/TestRemote.cs
@@ -13,6 +13,7 @@ namespace exampleapp.remotes
                 Msg = $"[REMOTE] hello from csharp :) {System.Guid.NewGuid().ToString()}, route={msg.Route}, msg={msg.Msg}",
                 Code = 200,
             };
+            Logger.Info($"Received RPC with message {msg.Msg}, {msg.Route}");
             return response;
         }
     }


### PR DESCRIPTION
In this PR, we fix Protobuf as the main communication protocol between backend servers, ignoring the defined serializer by the User. This follows the convention in the Golang implementation and enable proper communication with Golang servers.