### PR TITLE
Fix RPC context memory leak

### DIFF
--- a/pitaya-sharp/NPitaya/NPitaya.csproj
+++ b/pitaya-sharp/NPitaya/NPitaya.csproj
@@ -4,7 +4,7 @@
     <PropertyGroup>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <PackageId>NPitaya</PackageId>
-        <PackageVersion>0.16.0</PackageVersion>
+        <PackageVersion>0.16.1</PackageVersion>
         <Title>NPitaya</Title>
         <Authors>TFG Co</Authors>
         <Description>A full implementation of pitaya backend framework for .NET</Description>

--- a/pitaya-sharp/NPitaya/src/PitayaCluster.API.cs
+++ b/pitaya-sharp/NPitaya/src/PitayaCluster.API.cs
@@ -94,6 +94,10 @@ namespace NPitaya
             {
                 Logger.Error("Failed to decode request, error:{0}", e.Message);
             }
+            finally
+            {
+                pitaya_ctx_drop(ctx);
+            }
         }
 
         public static void Initialize(string envPrefix,

--- a/pitaya-sharp/NPitaya/src/PitayaCluster.Native.cs
+++ b/pitaya-sharp/NPitaya/src/PitayaCluster.Native.cs
@@ -134,6 +134,8 @@ namespace NPitaya
         private static extern IntPtr pitaya_rpc_respond(IntPtr rpc, IntPtr responseData, Int32 responseLen);
         [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
         private static extern IntPtr pitaya_rpc_drop(IntPtr rpc);
+        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+        private static extern IntPtr pitaya_ctx_drop(IntPtr ctx);
 
         //
         // Kick

--- a/src/pitaya/pitaya.h
+++ b/src/pitaya/pitaya.h
@@ -76,6 +76,8 @@ void pitaya_buffer_drop(PitayaBuffer *buf);
 
 PitayaBuffer *pitaya_buffer_new(const uint8_t *data, int32_t len);
 
+void pitaya_ctx_drop(PitayaContext *ctx);
+
 const char *pitaya_error_code(PitayaError *err);
 
 void pitaya_error_drop(PitayaError *error);

--- a/src/pitaya/src/ffi.rs
+++ b/src/pitaya/src/ffi.rs
@@ -361,9 +361,7 @@ pub extern "C" fn pitaya_rpc_respond(
 
 #[no_mangle]
 pub extern "C" fn pitaya_rpc_drop(rpc: *mut PitayaRpc) {
-    let _ = unsafe {
-        Box::from_raw(rpc);
-    };
+    let _ = unsafe { Box::from_raw(rpc) };
 }
 
 #[no_mangle]

--- a/src/pitaya/src/ffi.rs
+++ b/src/pitaya/src/ffi.rs
@@ -361,7 +361,12 @@ pub extern "C" fn pitaya_rpc_respond(
 
 #[no_mangle]
 pub extern "C" fn pitaya_rpc_drop(rpc: *mut PitayaRpc) {
-    let _ = unsafe { Box::from_raw(rpc) };
+    let _ = unsafe { Box::from_raw(rpc); };
+}
+
+#[no_mangle]
+pub extern "C" fn pitaya_ctx_drop(ctx: *mut PitayaContext) {
+    let _ = unsafe { Box::from_raw(ctx) };
 }
 
 // We are telling rust here that we know it is safe to send the

--- a/src/pitaya/src/ffi.rs
+++ b/src/pitaya/src/ffi.rs
@@ -361,7 +361,9 @@ pub extern "C" fn pitaya_rpc_respond(
 
 #[no_mangle]
 pub extern "C" fn pitaya_rpc_drop(rpc: *mut PitayaRpc) {
-    let _ = unsafe { Box::from_raw(rpc); };
+    let _ = unsafe {
+        Box::from_raw(rpc);
+    };
 }
 
 #[no_mangle]


### PR DESCRIPTION
We fix a known memory leak in the C# and Rust integration, regarding the RPC context exchanged between layers.