### PR TITLE
Fix histogram buckets in metrics exporting

### DIFF
--- a/pitaya-sharp/NPitaya/NPitaya.csproj
+++ b/pitaya-sharp/NPitaya/NPitaya.csproj
@@ -4,7 +4,7 @@
     <PropertyGroup>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <PackageId>NPitaya</PackageId>
-        <PackageVersion>0.16.1</PackageVersion>
+        <PackageVersion>0.16.2</PackageVersion>
         <Title>NPitaya</Title>
         <Authors>TFG Co</Authors>
         <Description>A full implementation of pitaya backend framework for .NET</Description>

--- a/pitaya-sharp/NPitaya/src/Metrics/CustomMetrics.cs
+++ b/pitaya-sharp/NPitaya/src/Metrics/CustomMetrics.cs
@@ -22,14 +22,14 @@ namespace NPitaya.Metrics
         Linear
     }
 
-    public struct CustomHistogramConfig
+    public struct HistogramBuckets
     {
         public readonly HistogramBucketType Kind;
         public readonly double Start;
         public readonly double Inc;
         public readonly uint Count;
 
-        public CustomHistogramConfig(HistogramBucketType kind, double start, double inc, uint count)
+        public HistogramBuckets(HistogramBucketType kind, double start, double inc, uint count)
         {
 
             Kind = kind;
@@ -41,15 +41,15 @@ namespace NPitaya.Metrics
 
     internal class HistogramSpec : MetricSpec
     {
-        public readonly CustomHistogramConfig BucketConfig;
+        public readonly HistogramBuckets Buckets;
 
         public HistogramSpec(
             string name,
             string help,
             string[] labels,
-            CustomHistogramConfig bucketConfig): base(name, help, labels)
+            HistogramBuckets buckets): base(name, help, labels)
         {
-            BucketConfig = bucketConfig;
+            Buckets = buckets;
         }
     }
 
@@ -76,9 +76,9 @@ namespace NPitaya.Metrics
             Gauges.Add(new MetricSpec(name, help, labels));
         }
 
-        public void AddHistogram(string name, CustomHistogramConfig bucketConfig, string help = null, string[] labels = null)
+        public void AddHistogram(string name, HistogramBuckets buckets, string help = null, string[] labels = null)
         {
-            Histograms.Add(new HistogramSpec(name, help, labels, bucketConfig));
+            Histograms.Add(new HistogramSpec(name, help, labels, buckets));
         }
     }
 }

--- a/pitaya-sharp/NPitaya/src/Metrics/CustomMetrics.cs
+++ b/pitaya-sharp/NPitaya/src/Metrics/CustomMetrics.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace NPitaya.Metrics
 {
-    internal readonly struct MetricSpec
+    internal class MetricSpec
     {
         internal readonly string Name;
         internal readonly string Help;
@@ -16,17 +16,54 @@ namespace NPitaya.Metrics
         }
     }
 
+    public enum HistogramBucketType
+    {
+        Exponential,
+        Linear
+    }
+
+    public struct CustomHistogramConfig
+    {
+        public readonly HistogramBucketType Kind;
+        public readonly double Start;
+        public readonly double Inc;
+        public readonly uint Count;
+
+        public CustomHistogramConfig(HistogramBucketType kind, double start, double inc, uint count)
+        {
+
+            Kind = kind;
+            Start = start;
+            Inc = inc;
+            Count = count;
+        }
+    }
+
+    internal class HistogramSpec : MetricSpec
+    {
+        public readonly CustomHistogramConfig BucketConfig;
+
+        public HistogramSpec(
+            string name,
+            string help,
+            string[] labels,
+            CustomHistogramConfig bucketConfig): base(name, help, labels)
+        {
+            BucketConfig = bucketConfig;
+        }
+    }
+
     public class CustomMetrics
     {
         internal readonly List<MetricSpec> Counters;
         internal readonly List<MetricSpec> Gauges;
-        internal readonly List<MetricSpec> Histograms;
+        internal readonly List<HistogramSpec> Histograms;
 
         public CustomMetrics()
         {
             Counters = new List<MetricSpec>();
             Gauges = new List<MetricSpec>();
-            Histograms = new List<MetricSpec>();
+            Histograms = new List<HistogramSpec>();
         }
 
         public void AddCounter(string name, string help = null, string[] labels = null)
@@ -39,9 +76,9 @@ namespace NPitaya.Metrics
             Gauges.Add(new MetricSpec(name, help, labels));
         }
 
-        public void AddHistogram(string name, string help = null, string[] labels = null)
+        public void AddHistogram(string name, CustomHistogramConfig bucketConfig, string help = null, string[] labels = null)
         {
-            Histograms.Add(new MetricSpec(name, help, labels));
+            Histograms.Add(new HistogramSpec(name, help, labels, bucketConfig));
         }
     }
 }

--- a/pitaya-sharp/NPitaya/src/Metrics/CustomMetrics.cs
+++ b/pitaya-sharp/NPitaya/src/Metrics/CustomMetrics.cs
@@ -31,7 +31,6 @@ namespace NPitaya.Metrics
 
         public HistogramBuckets(HistogramBucketKind kind, double start, double inc, uint count)
         {
-
             Kind = kind;
             Start = start;
             Inc = inc;

--- a/pitaya-sharp/NPitaya/src/Metrics/CustomMetrics.cs
+++ b/pitaya-sharp/NPitaya/src/Metrics/CustomMetrics.cs
@@ -16,7 +16,7 @@ namespace NPitaya.Metrics
         }
     }
 
-    public enum HistogramBucketType
+    public enum HistogramBucketKind
     {
         Exponential,
         Linear
@@ -24,12 +24,12 @@ namespace NPitaya.Metrics
 
     public struct HistogramBuckets
     {
-        public readonly HistogramBucketType Kind;
+        public readonly HistogramBucketKind Kind;
         public readonly double Start;
         public readonly double Inc;
         public readonly uint Count;
 
-        public HistogramBuckets(HistogramBucketType kind, double start, double inc, uint count)
+        public HistogramBuckets(HistogramBucketKind kind, double start, double inc, uint count)
         {
 
             Kind = kind;

--- a/pitaya-sharp/NPitaya/src/Metrics/PitayaReporter.cs
+++ b/pitaya-sharp/NPitaya/src/Metrics/PitayaReporter.cs
@@ -190,7 +190,7 @@ namespace NPitaya.Metrics
                 throw new Exception("Tried to register histogram with no buckets");
             }
 
-            var typeStr = Marshal.PtrToStringAnsi(buckets.Type);
+            var typeStr = Marshal.PtrToStringAnsi(buckets.Kind);
             HistogramBucketKind kind = typeStr switch
             {
                 "linear" => HistogramBucketKind.Linear,

--- a/pitaya-sharp/NPitaya/src/Metrics/PitayaReporter.cs
+++ b/pitaya-sharp/NPitaya/src/Metrics/PitayaReporter.cs
@@ -183,7 +183,7 @@ namespace NPitaya.Metrics
             return labels;
         }
 
-        static unsafe CustomHistogramConfig ReadBuckets(ref BucketOpts buckets)
+        static unsafe HistogramBuckets ReadBuckets(ref BucketOpts buckets)
         {
             if (buckets.Count == 0)
             {
@@ -198,7 +198,7 @@ namespace NPitaya.Metrics
                 _ => throw new Exception($"Invalid metric buckets type {typeStr}")
             };
 
-            return new CustomHistogramConfig(type, buckets.Start, buckets.Increment, buckets.Count);
+            return new HistogramBuckets(type, buckets.Start, buckets.Increment, buckets.Count);
         }
 
         private static string BuildKey(string suffix)

--- a/pitaya-sharp/NPitaya/src/Metrics/PitayaReporter.cs
+++ b/pitaya-sharp/NPitaya/src/Metrics/PitayaReporter.cs
@@ -191,14 +191,14 @@ namespace NPitaya.Metrics
             }
 
             var typeStr = Marshal.PtrToStringAnsi(buckets.Type);
-            HistogramBucketType type = typeStr switch
+            HistogramBucketKind kind = typeStr switch
             {
-                "linear" => HistogramBucketType.Linear,
-                "exponential" => HistogramBucketType.Exponential,
+                "linear" => HistogramBucketKind.Linear,
+                "exponential" => HistogramBucketKind.Exponential,
                 _ => throw new Exception($"Invalid metric buckets type {typeStr}")
             };
 
-            return new HistogramBuckets(type, buckets.Start, buckets.Increment, buckets.Count);
+            return new HistogramBuckets(kind, buckets.Start, buckets.Increment, buckets.Count);
         }
 
         private static string BuildKey(string suffix)

--- a/pitaya-sharp/NPitaya/src/Metrics/PitayaReporter.cs
+++ b/pitaya-sharp/NPitaya/src/Metrics/PitayaReporter.cs
@@ -76,11 +76,12 @@ namespace NPitaya.Metrics
                 Logger.Warn("Tried to register an histogram with an empty name");
                 return;
             }
-            var help = Marshal.PtrToStringAnsi(opts.Help) ?? string.Empty;
-            var labels = ReadLabels(opts.VariableLabels, opts.VariableLabelsCount);
             var prometheus = RetrievePrometheus(prometheusPtr);
             var key = BuildKey(name);
-            prometheus?.RegisterHistogram(key, help, labels);
+            var help = Marshal.PtrToStringAnsi(opts.Help) ?? string.Empty;
+            var labels = ReadLabels(opts.VariableLabels, opts.VariableLabelsCount);
+            var bucketsConfig = ReadBuckets(ref opts.Buckets);
+            prometheus?.RegisterHistogram(key, help, labels, bucketsConfig);
         }
 
         static void RegisterGaugeFn(IntPtr prometheusPtr, MetricsOpts opts)
@@ -180,6 +181,24 @@ namespace NPitaya.Metrics
             }
 
             return labels;
+        }
+
+        static unsafe CustomHistogramConfig ReadBuckets(ref BucketOpts buckets)
+        {
+            if (buckets.Count == 0)
+            {
+                throw new Exception("Tried to register histogram with no buckets");
+            }
+
+            var typeStr = Marshal.PtrToStringAnsi(buckets.Type);
+            HistogramBucketType type = typeStr switch
+            {
+                "linear" => HistogramBucketType.Linear,
+                "exponential" => HistogramBucketType.Exponential,
+                _ => throw new Exception($"Invalid metric buckets type {typeStr}")
+            };
+
+            return new CustomHistogramConfig(type, buckets.Start, buckets.Increment, buckets.Count);
         }
 
         private static string BuildKey(string suffix)

--- a/pitaya-sharp/NPitaya/src/Metrics/PrometheusReporter.cs
+++ b/pitaya-sharp/NPitaya/src/Metrics/PrometheusReporter.cs
@@ -85,7 +85,7 @@ namespace NPitaya.Metrics
 
         static HistogramConfiguration BuildHistogramConfig(HistogramBuckets buckets, string[] labels)
         {
-            var promBuckets = buckets.Kind == HistogramBucketType.Exponential
+            var promBuckets = buckets.Kind == HistogramBucketKind.Exponential
                 ? Histogram.ExponentialBuckets(buckets.Start, buckets.Inc, (int)buckets.Count)
                 : Histogram.LinearBuckets(buckets.Start, buckets.Inc, (int)buckets.Count);
             return new HistogramConfiguration{LabelNames = labels, Buckets = promBuckets};

--- a/pitaya-sharp/NPitaya/src/Metrics/PrometheusReporter.cs
+++ b/pitaya-sharp/NPitaya/src/Metrics/PrometheusReporter.cs
@@ -74,22 +74,21 @@ namespace NPitaya.Metrics
             _gauges.Add(key, gauge);
         }
 
-        internal void RegisterHistogram(string name, string help, string[] labels, CustomHistogramConfig bucketsConfig)
+        internal void RegisterHistogram(string name, string help, string[] labels, HistogramBuckets buckets)
         {
             var key = BuildKey(name);
-            var config = BuildHistogramConfig(bucketsConfig, labels);
+            var config = BuildHistogramConfig(buckets, labels);
             var histogram = Prometheus.Metrics.CreateHistogram(key, help, config);
             _histograms.Add(key, histogram);
             Logger.Debug($"Registered histogram metric {key}");
         }
 
-        static HistogramConfiguration BuildHistogramConfig(CustomHistogramConfig config, string[] labels)
+        static HistogramConfiguration BuildHistogramConfig(HistogramBuckets buckets, string[] labels)
         {
-            double[] buckets;
-            buckets = config.Kind == HistogramBucketType.Exponential
-                ? Histogram.ExponentialBuckets(config.Start, config.Inc, (int)config.Count)
-                : Histogram.LinearBuckets(config.Start, config.Inc, (int)config.Count);
-            return new HistogramConfiguration{LabelNames = labels, Buckets = buckets};
+            var promBuckets = buckets.Kind == HistogramBucketType.Exponential
+                ? Histogram.ExponentialBuckets(buckets.Start, buckets.Inc, (int)buckets.Count)
+                : Histogram.LinearBuckets(buckets.Start, buckets.Inc, (int)buckets.Count);
+            return new HistogramConfiguration{LabelNames = labels, Buckets = promBuckets};
         }
 
         internal void IncCounter(string name, string[]? labels)
@@ -146,7 +145,7 @@ namespace NPitaya.Metrics
 
             foreach (var metric in metrics.Histograms)
             {
-                RegisterHistogram(metric.Name, metric.Help, metric.Labels, metric.BucketConfig);
+                RegisterHistogram(metric.Name, metric.Help, metric.Labels, metric.Buckets);
             }
         }
     }

--- a/pitaya-sharp/NPitaya/src/NativeInterop.cs
+++ b/pitaya-sharp/NPitaya/src/NativeInterop.cs
@@ -3,6 +3,14 @@ using System.Runtime.InteropServices;
 
 namespace NPitaya
 {
+    public enum MetricType : byte
+    {
+        Counter = 0,
+        Gauge,
+        Histogram,
+        Summary
+    }
+
     [StructLayout(LayoutKind.Sequential)]
     public struct MetricsOpts
     {
@@ -12,8 +20,16 @@ namespace NPitaya
         public IntPtr Help;
         public IntPtr VariableLabels;
         public UInt32 VariableLabelsCount;
-        public IntPtr Buckets;
-        public UInt32 BucketsCount;
+        public BucketOpts Buckets;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct BucketOpts
+    {
+        public IntPtr Type;
+        public double Start;
+        public double Increment;
+        public UInt32 Count;
     }
 
     public struct PitayaError

--- a/pitaya-sharp/NPitaya/src/NativeInterop.cs
+++ b/pitaya-sharp/NPitaya/src/NativeInterop.cs
@@ -3,14 +3,6 @@ using System.Runtime.InteropServices;
 
 namespace NPitaya
 {
-    public enum MetricType : byte
-    {
-        Counter = 0,
-        Gauge,
-        Histogram,
-        Summary
-    }
-
     [StructLayout(LayoutKind.Sequential)]
     public struct MetricsOpts
     {

--- a/pitaya-sharp/NPitaya/src/NativeInterop.cs
+++ b/pitaya-sharp/NPitaya/src/NativeInterop.cs
@@ -18,7 +18,7 @@ namespace NPitaya
     [StructLayout(LayoutKind.Sequential)]
     public struct BucketOpts
     {
-        public IntPtr Type;
+        public IntPtr Kind;
         public double Start;
         public double Increment;
         public UInt32 Count;

--- a/pitaya-sharp/NPitaya/src/PitayaCluster.API.cs
+++ b/pitaya-sharp/NPitaya/src/PitayaCluster.API.cs
@@ -307,7 +307,7 @@ namespace NPitaya
             _metricsReporter?.SetGauge(name, value, labels);
         }
 
-        public static void IncCounter(string name, float value, string[]? labels = null)
+        public static void ObserveHistogram(string name, float value, string[]? labels = null)
         {
             _metricsReporter?.ObserveHistogram(name, value, labels);
         }

--- a/pitaya-sharp/exampleapp/Program.cs
+++ b/pitaya-sharp/exampleapp/Program.cs
@@ -31,7 +31,7 @@ namespace PitayaCSharpExample
             var customMetrics = new CustomMetrics();
             customMetrics.AddHistogram(
                 "my_histogram",
-                new HistogramBuckets(HistogramBucketType.Linear, 1, 2, 10),
+                new HistogramBuckets(HistogramBucketKind.Linear, 1, 2, 10),
                 "Some test histogram",
                 new []{"my_label"});
             var metricsParameters = new MetricsConfiguration(

--- a/pitaya-sharp/exampleapp/Program.cs
+++ b/pitaya-sharp/exampleapp/Program.cs
@@ -28,7 +28,18 @@ namespace PitayaCSharpExample
                 PitayaCluster.Terminate();
             };
 
-            var metricsParameters = new MetricsConfiguration(false, "127.0.0.1", "8000", "myns", null);
+            var customMetrics = new CustomMetrics();
+            customMetrics.AddHistogram(
+                "my_histogram",
+                new HistogramBuckets(HistogramBucketType.Linear, 1, 2, 10),
+                "Some test histogram",
+                new []{"my_label"});
+            var metricsParameters = new MetricsConfiguration(
+                true,
+                "127.0.0.1",
+                "8000",
+                "myns",
+                customMetrics);
 
             try
             {
@@ -100,6 +111,7 @@ namespace PitayaCSharpExample
                 Console.WriteLine("GOT MESSAGE!!!");
                 Console.WriteLine($"Code: {res.Code}");
                 Console.WriteLine($"Msg: {res.Msg}");
+                PitayaCluster.ObserveHistogram("my_histogram", 3, new []{"its_value"});
             }
             catch (PitayaException e)
             {

--- a/src/pitaya/examples/cluster.rs
+++ b/src/pitaya/examples/cluster.rs
@@ -153,7 +153,7 @@ async fn main() {
             name: "metric_name".into(),
             help: "super help".into(),
             variable_labels: vec![],
-            buckets: Option::None,
+            buckets: None,
         })
         .unwrap();
 

--- a/src/pitaya/examples/cluster.rs
+++ b/src/pitaya/examples/cluster.rs
@@ -153,7 +153,7 @@ async fn main() {
             name: "metric_name".into(),
             help: "super help".into(),
             variable_labels: vec![],
-            buckets: vec![],
+            buckets: Option::None,
         })
         .unwrap();
 

--- a/src/pitaya/pitaya.h
+++ b/src/pitaya/pitaya.h
@@ -50,14 +50,20 @@ typedef void (*PitayaHandleRpcCallback)(void*, PitayaContext*, PitayaRpc*);
 typedef void (*PitayaClusterNotificationCallback)(void*, PitayaClusterNotification, PitayaServerInfo*);
 
 typedef struct {
+    const char *kind;
+    double start;
+    double inc;
+    uint32_t count;
+} PitayaHistBucketOpts;
+
+typedef struct {
     const char *namespace_;
     const char *subsystem;
     const char *name;
     const char *help;
     const char **variable_labels;
     uint32_t variable_labels_count;
-    double *buckets;
-    uint32_t buckets_count;
+    PitayaHistBucketOpts buckets;
 } PitayaMetricsOpts;
 
 typedef void (*PitayaRegisterFn)(void *user_data, PitayaMetricsOpts opts);

--- a/src/pitaya/src/ffi/metrics.rs
+++ b/src/pitaya/src/ffi/metrics.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use std::{
     ffi::{c_void, CString},
     os::raw::c_char,
-    os::raw::c_double
+    os::raw::c_double,
 };
 
 #[repr(C)]
@@ -95,24 +95,24 @@ fn generic_register(
     let name = CString::new(opts.name.as_str()).expect("string should be valid inside rust");
     let help = CString::new(opts.help.as_str()).expect("string should be valid inside rust");
     let mut bucket_kind: CString = Default::default();
-    let buckets = opts.buckets
+    let buckets = opts
+        .buckets
         .map(|b| {
-            bucket_kind = CString::new(b.kind.as_str()).expect("string should be valid inside rust");        
-            PitayaHistBucketOpts{
+            bucket_kind =
+                CString::new(b.kind.as_str()).expect("string should be valid inside rust");
+            PitayaHistBucketOpts {
                 kind: bucket_kind.as_ptr(),
                 start: b.start,
                 inc: b.inc,
                 count: b.count as u32,
             }
         })
-        .unwrap_or_else(|| PitayaHistBucketOpts{
+        .unwrap_or_else(|| PitayaHistBucketOpts {
             kind: std::ptr::null(),
             start: 1.0,
             inc: 1.0,
             count: 1,
-        });  
-        
-        println!("{:?}", buckets);
+        });
 
     let opts = PitayaMetricsOpts {
         namespace: namespace.as_ptr(),

--- a/src/pitaya/src/ffi/metrics.rs
+++ b/src/pitaya/src/ffi/metrics.rs
@@ -1,8 +1,7 @@
 use async_trait::async_trait;
 use std::{
     ffi::{c_void, CString},
-    os::raw::c_char,
-    os::raw::c_double,
+    os::raw::{c_char, c_double},
 };
 
 #[repr(C)]

--- a/src/pitaya/src/ffi/metrics.rs
+++ b/src/pitaya/src/ffi/metrics.rs
@@ -108,9 +108,9 @@ fn generic_register(
         })
         .unwrap_or_else(|| PitayaHistBucketOpts {
             kind: std::ptr::null(),
-            start: 1.0,
-            inc: 1.0,
-            count: 1,
+            start: 0.0,
+            inc: 0.0,
+            count: 0,
         });
 
     let opts = PitayaMetricsOpts {

--- a/src/pitaya/src/ffi/metrics.rs
+++ b/src/pitaya/src/ffi/metrics.rs
@@ -93,24 +93,31 @@ fn generic_register(
         CString::new(opts.subsystem.as_str()).expect("string should be valid inside rust");
     let name = CString::new(opts.name.as_str()).expect("string should be valid inside rust");
     let help = CString::new(opts.help.as_str()).expect("string should be valid inside rust");
-    let mut bucket_kind: CString = Default::default();
-    let buckets = opts
+    let (buckets, _) = opts
         .buckets
         .map(|b| {
-            bucket_kind =
+            let bucket_kind =
                 CString::new(b.kind.as_str()).expect("string should be valid inside rust");
-            PitayaHistBucketOpts {
-                kind: bucket_kind.as_ptr(),
-                start: b.start,
-                inc: b.inc,
-                count: b.count as u32,
-            }
+            (
+                PitayaHistBucketOpts {
+                    kind: bucket_kind.as_ptr(),
+                    start: b.start,
+                    inc: b.inc,
+                    count: b.count as u32,
+                },
+                bucket_kind,
+            )
         })
-        .unwrap_or_else(|| PitayaHistBucketOpts {
-            kind: std::ptr::null(),
-            start: 0.0,
-            inc: 0.0,
-            count: 0,
+        .unwrap_or_else(|| {
+            (
+                PitayaHistBucketOpts {
+                    kind: std::ptr::null(),
+                    start: 0.0,
+                    inc: 0.0,
+                    count: 0,
+                },
+                Default::default(),
+            )
         });
 
     let opts = PitayaMetricsOpts {

--- a/src/pitaya/src/ffi/metrics.rs
+++ b/src/pitaya/src/ffi/metrics.rs
@@ -2,6 +2,7 @@ use async_trait::async_trait;
 use std::{
     ffi::{c_void, CString},
     os::raw::c_char,
+    os::raw::c_double
 };
 
 #[repr(C)]
@@ -12,8 +13,16 @@ pub struct PitayaMetricsOpts {
     pub help: *const c_char,
     pub variable_labels: *mut *const c_char,
     pub variable_labels_count: u32,
-    pub buckets: *mut f64,
-    pub buckets_count: u32,
+    pub buckets: PitayaHistBucketOpts,
+}
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct PitayaHistBucketOpts {
+    pub kind: *const c_char,
+    pub start: c_double,
+    pub inc: c_double,
+    pub count: u32,
 }
 
 type PitayaRegisterFn = extern "C" fn(user_data: *mut c_void, opts: PitayaMetricsOpts);
@@ -63,7 +72,7 @@ pub struct PitayaMetricsReporter {
 fn generic_register(
     register_fn: extern "C" fn(*mut c_void, PitayaMetricsOpts),
     user_data: *mut c_void,
-    mut opts: crate::metrics::Opts,
+    opts: crate::metrics::Opts,
 ) {
     // TODO(lhahn): this function allocates a lot of unnecessary memory.
     // consider improving this in the future.
@@ -85,6 +94,25 @@ fn generic_register(
         CString::new(opts.subsystem.as_str()).expect("string should be valid inside rust");
     let name = CString::new(opts.name.as_str()).expect("string should be valid inside rust");
     let help = CString::new(opts.help.as_str()).expect("string should be valid inside rust");
+    let mut bucket_kind: CString = Default::default();
+    let buckets = opts.buckets
+        .map(|b| {
+            bucket_kind = CString::new(b.kind.as_str()).expect("string should be valid inside rust");        
+            PitayaHistBucketOpts{
+                kind: bucket_kind.as_ptr(),
+                start: b.start,
+                inc: b.inc,
+                count: b.count as u32,
+            }
+        })
+        .unwrap_or_else(|| PitayaHistBucketOpts{
+            kind: std::ptr::null(),
+            start: 1.0,
+            inc: 1.0,
+            count: 1,
+        });  
+        
+        println!("{:?}", buckets);
 
     let opts = PitayaMetricsOpts {
         namespace: namespace.as_ptr(),
@@ -93,8 +121,7 @@ fn generic_register(
         help: help.as_ptr(),
         variable_labels: variable_labels_ptr.as_mut_ptr(),
         variable_labels_count: variable_labels_ptr.len() as u32,
-        buckets: opts.buckets.as_mut_ptr(),
-        buckets_count: opts.buckets.len() as u32,
+        buckets: buckets,
     };
 
     register_fn(user_data, opts);

--- a/src/pitaya/src/ffi/metrics.rs
+++ b/src/pitaya/src/ffi/metrics.rs
@@ -121,7 +121,7 @@ fn generic_register(
         help: help.as_ptr(),
         variable_labels: variable_labels_ptr.as_mut_ptr(),
         variable_labels_count: variable_labels_ptr.len() as u32,
-        buckets: buckets,
+        buckets,
     };
 
     register_fn(user_data, opts);

--- a/src/pitaya_core/src/metrics.rs
+++ b/src/pitaya_core/src/metrics.rs
@@ -144,11 +144,11 @@ pub fn exponential_buckets(start: f64, factor: f64, count: usize) -> BucketOpts 
     assert!(count >= 1);
     assert!(start > 0.0);
     assert!(factor > 1.0);
-    let buckets = BucketOpts{
+    let buckets = BucketOpts {
         kind: "exponential".to_string(),
         start: start,
         inc: factor,
-        count: count
+        count: count,
     };
 
     buckets

--- a/src/pitaya_core/src/metrics.rs
+++ b/src/pitaya_core/src/metrics.rs
@@ -19,6 +19,7 @@ pub enum MetricKind {
     Histogram,
 }
 
+#[derive(Debug, PartialEq)]
 pub struct BucketOpts {
     pub kind: String,
     pub start: f64,
@@ -102,42 +103,6 @@ impl Reporter for DummyReporter {
     fn add_gauge(&self, _name: &str, _value: f64, _labels: &[&str]) -> Result<(), Error> {
         Ok(())
     }
-}
-
-/// Creates buckets that are incremented exponentially.
-///
-/// # Examples
-/// ```
-/// let buckets = pitaya_core::metrics::exponential_buckets(1.0, 2.5, 5);
-/// assert_eq!(buckets, vec![1.0, 2.5, 6.25, 15.625, 39.0625]);
-/// ```
-///
-/// # Panics
-/// This function panics if count is zero, start is less than or equal to zero
-/// or factor is smaller than one.
-///
-/// ```rust,should_panic
-/// let _ = pitaya_core::metrics::exponential_buckets(1.0, 2.5, 0);
-/// ```
-/// ```rust,should_panic
-/// let _ = pitaya_core::metrics::exponential_buckets(-1.0, 2.5, 5);
-/// ```
-/// ```rust,should_panic
-/// let _ = pitaya_core::metrics::exponential_buckets(1.0, 0.5, 5);
-/// ```
-pub fn exponential_buckets_old(start: f64, factor: f64, count: usize) -> Vec<f64> {
-    assert!(count >= 1);
-    assert!(start > 0.0);
-    assert!(factor > 1.0);
-
-    let mut next = start;
-    let mut buckets = Vec::with_capacity(count);
-    for _ in 0..count {
-        buckets.push(next);
-        next *= factor;
-    }
-
-    buckets
 }
 
 pub fn exponential_buckets(start: f64, factor: f64, count: usize) -> BucketOpts {

--- a/src/pitaya_core/src/metrics.rs
+++ b/src/pitaya_core/src/metrics.rs
@@ -14,9 +14,16 @@ pub enum Error {
 
 #[derive(Debug, PartialEq)]
 pub enum MetricKind {
-    Histogram,
-    Gauge,
     Counter,
+    Gauge,
+    Histogram,
+}
+
+pub struct BucketOpts {
+    pub kind: String,
+    pub start: f64,
+    pub inc: f64,
+    pub count: usize,
 }
 
 /// The options required for a metric.
@@ -32,7 +39,7 @@ pub struct Opts {
     /// The labels that are used for this metric.
     pub variable_labels: Vec<String>,
     /// The buckets for a histogram. This field is ignored for other metric kinds.
-    pub buckets: Vec<f64>,
+    pub buckets: Option<BucketOpts>,
 }
 
 /// Represents a reporter that can be used across multiple threads.
@@ -118,7 +125,7 @@ impl Reporter for DummyReporter {
 /// ```rust,should_panic
 /// let _ = pitaya_core::metrics::exponential_buckets(1.0, 0.5, 5);
 /// ```
-pub fn exponential_buckets(start: f64, factor: f64, count: usize) -> Vec<f64> {
+pub fn exponential_buckets_old(start: f64, factor: f64, count: usize) -> Vec<f64> {
     assert!(count >= 1);
     assert!(start > 0.0);
     assert!(factor > 1.0);
@@ -129,6 +136,20 @@ pub fn exponential_buckets(start: f64, factor: f64, count: usize) -> Vec<f64> {
         buckets.push(next);
         next *= factor;
     }
+
+    buckets
+}
+
+pub fn exponential_buckets(start: f64, factor: f64, count: usize) -> BucketOpts {
+    assert!(count >= 1);
+    assert!(start > 0.0);
+    assert!(factor > 1.0);
+    let buckets = BucketOpts{
+        kind: "exponential".to_string(),
+        start: start,
+        inc: factor,
+        count: count
+    };
 
     buckets
 }

--- a/src/pitaya_core/src/metrics.rs
+++ b/src/pitaya_core/src/metrics.rs
@@ -144,14 +144,12 @@ pub fn exponential_buckets(start: f64, factor: f64, count: usize) -> BucketOpts 
     assert!(count >= 1);
     assert!(start > 0.0);
     assert!(factor > 1.0);
-    let buckets = BucketOpts {
+    BucketOpts {
         kind: "exponential".to_string(),
         start,
         inc: factor,
         count,
-    };
-
-    buckets
+    }
 }
 
 pub async fn record_histogram_duration<'a>(

--- a/src/pitaya_core/src/metrics.rs
+++ b/src/pitaya_core/src/metrics.rs
@@ -146,9 +146,9 @@ pub fn exponential_buckets(start: f64, factor: f64, count: usize) -> BucketOpts 
     assert!(factor > 1.0);
     let buckets = BucketOpts {
         kind: "exponential".to_string(),
-        start: start,
+        start,
         inc: factor,
-        count: count,
+        count,
     };
 
     buckets

--- a/src/pitaya_etcd_nats_cluster/src/rpc_client.rs
+++ b/src/pitaya_etcd_nats_cluster/src/rpc_client.rs
@@ -46,7 +46,7 @@ impl NatsRpcClient {
                 name: String::from(CLIENT_LATENCY_METRIC),
                 help: String::from("histogram of client rpc latency in seconds"),
                 variable_labels: vec!["status".to_string()],
-                buckets: metrics::exponential_buckets(0.0005, 2.0, 20),
+                buckets: Some(metrics::exponential_buckets(0.0005, 2.0, 20)),
             })
             .expect("should not fail to register");
     }

--- a/src/pitaya_etcd_nats_cluster/src/rpc_server.rs
+++ b/src/pitaya_etcd_nats_cluster/src/rpc_server.rs
@@ -207,7 +207,7 @@ impl NatsRpcServer {
                 name: String::from(RPC_LATENCY_METRIC),
                 help: String::from("histogram of rpc latency in seconds"),
                 variable_labels: vec!["route".to_string(), "status".to_string()],
-                buckets: metrics::exponential_buckets(0.0005, 2.0, 20),
+                buckets: Some(metrics::exponential_buckets(0.0005, 2.0, 20)),
             })
             .expect("should not fail to register");
 
@@ -221,7 +221,7 @@ impl NatsRpcServer {
                 name: String::from(RPCS_IN_FLIGHT_METRIC),
                 help: String::from("number of in-flight RPCs at the moment"),
                 variable_labels: vec![],
-                buckets: vec![],
+                buckets: None,
             })
             .expect("should not failed to register");
     }

--- a/src/prometheus_metrics/src/lib.rs
+++ b/src/prometheus_metrics/src/lib.rs
@@ -4,7 +4,7 @@ use hyper::{
     service::{make_service_fn, service_fn},
     Body, Method, Request, Response, Server,
 };
-use pitaya_core::metrics::{Error, Opts, BucketOpts, Reporter};
+use pitaya_core::metrics::{BucketOpts, Error, Opts, Reporter};
 use prometheus::{Encoder, TextEncoder};
 use slog::{error, info};
 use std::{collections::HashMap, net::SocketAddr, sync::Arc};

--- a/src/prometheus_metrics/src/lib.rs
+++ b/src/prometheus_metrics/src/lib.rs
@@ -4,7 +4,7 @@ use hyper::{
     service::{make_service_fn, service_fn},
     Body, Method, Request, Response, Server,
 };
-use pitaya_core::metrics::{Error, Opts, Reporter};
+use pitaya_core::metrics::{Error, Opts, BucketOpts, Reporter};
 use prometheus::{Encoder, TextEncoder};
 use slog::{error, info};
 use std::{collections::HashMap, net::SocketAddr, sync::Arc};
@@ -123,7 +123,7 @@ impl Reporter for PrometheusReporter {
                 const_labels: self.const_labels.clone(),
                 variable_labels: vec![],
             },
-            buckets: opts.buckets,
+            buckets: to_prometheus_buckets(opts.buckets.unwrap()),
         };
         let label_names: Vec<&str> = opts.variable_labels.iter().map(|e| e.as_str()).collect();
         let collector = prometheus::HistogramVec::new(prometheus_opts, &label_names)
@@ -257,4 +257,23 @@ async fn metrics_handler(
             .status(hyper::StatusCode::NOT_FOUND)
             .body(Body::from("")),
     }
+}
+
+fn to_prometheus_buckets(opts: BucketOpts) -> Vec<f64> {
+    assert!(opts.count >= 1);
+    assert!(opts.start > 0.0);
+    assert!(opts.inc > 0.0);
+
+    let mut next = opts.start;
+    let mut buckets = Vec::with_capacity(opts.count);
+    for _ in 0..opts.count {
+        buckets.push(next);
+        if opts.kind == "linear" {
+            next += opts.inc;
+        } else {
+            next *= opts.inc;
+        }
+    }
+
+    buckets
 }


### PR DESCRIPTION
In this PR, properly set buckets values coming both from Pitaya reporter and custom metrics, which wasn't being correctly configured.