### PR TITLE
Fix macOS symbols file

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -124,6 +124,8 @@ jobs:
         run: |
           chmod 744 libpitaya.dylib
           chmod 744 libpitaya.so
+          mkdir -p target/release
+          mv libpitaya.dylib libpitaya.so target/release
 
       - name: "Build NPitaya"
         run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   test:
-    name: test pitaya
+    name: Test Pitaya Rust
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -32,7 +32,7 @@ jobs:
           makers undeps
 
   build-mac:
-    name: build pitaya for mac
+    name: Build for macOS
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
@@ -61,7 +61,7 @@ jobs:
           path: libpitaya.dylib.tar
 
   build-linux:
-    name: build pitaya for linux
+    name: Build for Linux
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -87,7 +87,7 @@ jobs:
           path: libpitaya.so.tar
 
   lint:
-    name: lint
+    name: Lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -107,7 +107,7 @@ jobs:
         run: cargo clippy --all --tests
 
   nupkg:
-    name: create nupkg
+    name: Create .nupkg
     runs-on: ubuntu-latest
     needs:
       - test
@@ -119,12 +119,12 @@ jobs:
         with:
           submodules: true
 
-      # Download Mac binary
+      # Download Linux binary
       - uses: actions/download-artifact@v2
         with:
           name: libpitaya.so.tar
 
-      # Download Libnux binary
+      # Download macOS binary
       - uses: actions/download-artifact@v2
         with:
           name: libpitaya.dylib.tar
@@ -135,7 +135,7 @@ jobs:
           tar -xvf libpitaya.dylib.tar
           tar -xvf libpitaya.so.tar
 
-      - name: "build c#"
+      - name: "Build NPitaya"
         run: |
           cd pitaya-sharp
           make pack

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,17 +48,11 @@ jobs:
       - name: Build Pitaya
         run: cargo build --release
 
-      # We have to tar the artifact before upload, otherwise we'll lose 
-      # permissions of the executable when downloading the artifact again.
-      # Ref: https://github.com/actions/download-artifact#maintaining-file-permissions-and-case-sensitive-files
-      - name: Tar Build Artifact
-        run: tar -cvf libpitaya.dylib.tar target/release/libpitaya.dylib
-
       - name: Upload Build Artifact
         uses: actions/upload-artifact@v2
         with:
-          name: libpitaya.dylib.tar
-          path: libpitaya.dylib.tar
+          name: libpitaya.dylib
+          path: target/release/libpitaya.dylib
 
   build-linux:
     name: Build for Linux
@@ -74,17 +68,11 @@ jobs:
       - name: Build Pitaya
         run: cargo build --release
 
-      # We have to tar the artifact before upload, otherwise we'll lose 
-      # permissions of the executable when downloading the artifact again.
-      # Ref: https://github.com/actions/download-artifact#maintaining-file-permissions-and-case-sensitive-files
-      - name: Tar Build Artifact
-        run: tar -cvf libpitaya.so.tar target/release/libpitaya.so
-
       - name: Upload Build Artifact
         uses: actions/upload-artifact@v2
         with:
-          name: libpitaya.so.tar
-          path: libpitaya.so.tar
+          name: libpitaya.so
+          path: target/release/libpitaya.so
 
   lint:
     name: Lint
@@ -122,18 +110,20 @@ jobs:
       # Download Linux binary
       - uses: actions/download-artifact@v2
         with:
-          name: libpitaya.so.tar
+          name: libpitaya.so
 
       # Download macOS binary
       - uses: actions/download-artifact@v2
         with:
-          name: libpitaya.dylib.tar
+          name: libpitaya.dylib
         
-      # Open Mac and Linux archives
-      - name: "open mac and linux archives"
+      # We have fix binaries permissions, because they're lost during artifact
+      # upload.
+      # Ref: https://github.com/actions/download-artifact#maintaining-file-permissions-and-case-sensitive-files
+      - name: "Fix permissions"
         run: |
-          tar -xvf libpitaya.dylib.tar
-          tar -xvf libpitaya.so.tar
+          chmod 744 libpitaya.dylib
+          chmod 744 libpitaya.so
 
       - name: "Build NPitaya"
         run: |

--- a/pitaya-sharp/Makefile
+++ b/pitaya-sharp/Makefile
@@ -12,6 +12,7 @@ test: start-test-deps
 clean:
 	@dotnet clean NPitaya
 	@rm -rf NPitaya/bin/Release
+	@rm -rf NPitaya/bin/Debug
 
 .PHONY: build
 build: clean

--- a/pitaya-sharp/NPitaya/NPitaya.csproj
+++ b/pitaya-sharp/NPitaya/NPitaya.csproj
@@ -4,7 +4,7 @@
     <PropertyGroup>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <PackageId>NPitaya</PackageId>
-        <PackageVersion>0.16.2</PackageVersion>
+        <PackageVersion>0.16.3</PackageVersion>
         <Title>NPitaya</Title>
         <Authors>TFG Co</Authors>
         <Description>A full implementation of pitaya backend framework for .NET</Description>


### PR DESCRIPTION
This PR tries to fix the binaries for macOS build that were being messed up during its compression with TAR in the Github Actions pipeline. The reason is unknown and, for now, we rely on sending the plain symbols file with permissions corrected in order to make it work.