### PR TITLE
Reduce marshalling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ main
 .DS_Store
 .idea/
 main
+
+.fake
+.ionide

--- a/pitaya-sharp/NPitaya/NPitaya.csproj
+++ b/pitaya-sharp/NPitaya/NPitaya.csproj
@@ -4,7 +4,7 @@
     <PropertyGroup>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <PackageId>NPitaya</PackageId>
-        <PackageVersion>0.16.5</PackageVersion>
+        <PackageVersion>0.16.6</PackageVersion>
         <Title>NPitaya</Title>
         <Authors>TFG Co</Authors>
         <Description>A full implementation of pitaya backend framework for .NET</Description>

--- a/pitaya-sharp/NPitaya/src/Metrics/MetricsConfiguration.cs
+++ b/pitaya-sharp/NPitaya/src/Metrics/MetricsConfiguration.cs
@@ -6,7 +6,7 @@ namespace NPitaya.Metrics
         internal readonly string Host;
         internal readonly string Port;
         internal readonly string Namespace;
-        internal readonly CustomMetrics? CustomMetrics;
+        internal CustomMetrics? CustomMetrics;
 
         public MetricsConfiguration(bool isEnabled, string host, string port, string ns, CustomMetrics? customMetrics)
         {

--- a/pitaya-sharp/NPitaya/src/Metrics/PrometheusReporter.cs
+++ b/pitaya-sharp/NPitaya/src/Metrics/PrometheusReporter.cs
@@ -35,7 +35,7 @@ namespace NPitaya.Metrics
             _namespace = @namespace;
             _host = host;
             _port = int.Parse(port);
-            _server = new MetricServer(hostname: _host, port: _port);
+            _server = new MetricServer(hostname: _host, port: _port, url: "metrics/");
             _counters = new Dictionary<string, Counter>();
             _gauges = new Dictionary<string, Gauge>();
             _histograms = new Dictionary<string, Histogram>();

--- a/pitaya-sharp/NPitaya/src/PitayaCluster.API.cs
+++ b/pitaya-sharp/NPitaya/src/PitayaCluster.API.cs
@@ -18,7 +18,8 @@ namespace NPitaya
     // Allows making RPC calls to other Pitaya servers.
     public partial class PitayaCluster
     {
-        private static ISerializer _serializer = new JSONSerializer();
+        const string RPC_LATENCY_METRIC = "rpc_latency";
+        static ISerializer _serializer = new JSONSerializer();
         static ProtobufSerializer _remoteSerializer = new ProtobufSerializer();
         public delegate string RemoteNameFunc(string methodName);
         delegate void OnSignalFunc();
@@ -113,6 +114,13 @@ namespace NPitaya
             var pitayaMetrics = IntPtr.Zero;
             if (metricsConfig.IsEnabled)
             {
+                if (metricsConfig.CustomMetrics == null) {
+                    metricsConfig.CustomMetrics = new CustomMetrics();
+                }
+                metricsConfig.CustomMetrics.AddHistogram(
+                    RPC_LATENCY_METRIC,
+                    new HistogramBuckets(HistogramBucketKind.Exponential, 0.0005, 2.0, 20)
+                );
                 _metricsReporter = new MetricsReporter(metricsConfig);
                 pitayaMetrics = _metricsReporter.GetPitayaPtr();
             }

--- a/pitaya-sharp/NPitaya/src/PitayaCluster.API.cs
+++ b/pitaya-sharp/NPitaya/src/PitayaCluster.API.cs
@@ -48,7 +48,7 @@ namespace NPitaya
             }
         }
 
-        static ServiceDiscoveryListener _serviceDiscoveryListener;
+        static ServiceDiscoveryListener? _serviceDiscoveryListener;
 
         public static void AddSignalHandler(Action cb)
         {
@@ -77,7 +77,7 @@ namespace NPitaya
             );
         }
 
-        static void HandleRpcCallback(IntPtr userData, IntPtr ctx, IntPtr rpc)
+        static void HandleRpcCallback(IntPtr userData, IntPtr rpc)
         {
             Int32 len;
             IntPtr rawData = pitaya_rpc_request(rpc, out len);
@@ -93,10 +93,6 @@ namespace NPitaya
             catch (Exception e)
             {
                 Logger.Error("Failed to decode request, error:{0}", e.Message);
-            }
-            finally
-            {
-                pitaya_ctx_drop(ctx);
             }
         }
 

--- a/pitaya-sharp/NPitaya/src/PitayaCluster.Native.cs
+++ b/pitaya-sharp/NPitaya/src/PitayaCluster.Native.cs
@@ -24,7 +24,7 @@ namespace NPitaya
         private delegate void LogFunction(IntPtr context, IntPtr msg);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        private delegate void HandleRpcCallbackFunc(IntPtr userData, IntPtr ctx, IntPtr rpc);
+        private delegate void HandleRpcCallbackFunc(IntPtr userData, IntPtr rpc);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void ClusterNotificationCallbackFunc(IntPtr userData, NotificationType notificationType, IntPtr data);
@@ -134,8 +134,6 @@ namespace NPitaya
         private static extern IntPtr pitaya_rpc_respond(IntPtr rpc, IntPtr responseData, Int32 responseLen);
         [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
         private static extern IntPtr pitaya_rpc_drop(IntPtr rpc);
-        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
-        private static extern IntPtr pitaya_ctx_drop(IntPtr ctx);
 
         //
         // Kick

--- a/pitaya-sharp/NPitaya/src/PitayaCluster.RPC.cs
+++ b/pitaya-sharp/NPitaya/src/PitayaCluster.RPC.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using Google.Protobuf;
 using NPitaya.Models;
@@ -101,6 +102,7 @@ namespace NPitaya
         static void DispatchRpc(RpcClient rpcClient, IntPtr rpc, Protos.Request req)
         {
             Task.Run(async () => {
+                var start = Stopwatch.StartNew();
                 var res = new Protos.Response();
                 try
                 {
@@ -121,6 +123,8 @@ namespace NPitaya
                 }
                 finally
                 {
+                    start.Stop();
+                    _metricsReporter?.ObserveHistogram(RPC_LATENCY_METRIC, (float)start.Elapsed.TotalSeconds, null);
                     unsafe
                     {
                         byte[] responseData = res.ToByteArray();

--- a/src/pitaya/pitaya.h
+++ b/src/pitaya/pitaya.h
@@ -35,8 +35,6 @@ typedef struct Pitaya Pitaya;
 
 typedef struct PitayaBuffer PitayaBuffer;
 
-typedef struct PitayaContext PitayaContext;
-
 typedef struct PitayaError PitayaError;
 
 typedef struct PitayaMetricsReporter PitayaMetricsReporter;
@@ -45,7 +43,7 @@ typedef struct PitayaRpc PitayaRpc;
 
 typedef struct PitayaServerInfo PitayaServerInfo;
 
-typedef void (*PitayaHandleRpcCallback)(void*, PitayaContext*, PitayaRpc*);
+typedef void (*PitayaHandleRpcCallback)(void*, PitayaRpc*);
 
 typedef void (*PitayaClusterNotificationCallback)(void*, PitayaClusterNotification, PitayaServerInfo*);
 
@@ -81,8 +79,6 @@ const uint8_t *pitaya_buffer_data(PitayaBuffer *buf, int32_t *len);
 void pitaya_buffer_drop(PitayaBuffer *buf);
 
 PitayaBuffer *pitaya_buffer_new(const uint8_t *data, int32_t len);
-
-void pitaya_ctx_drop(PitayaContext *ctx);
 
 const char *pitaya_error_code(PitayaError *err);
 

--- a/src/pitaya/src/lib.rs
+++ b/src/pitaya/src/lib.rs
@@ -10,7 +10,7 @@ pub use pitaya_core::{
 };
 use pitaya_core::{
     cluster::server::{ServerId, ServerInfo, ServerKind},
-    constants as core_constants, context,
+    context,
     service::{self, RpcHandler},
     Route,
 };
@@ -362,26 +362,12 @@ impl Pitaya {
             }
 
             let rpc = maybe_rpc.unwrap();
-            let logger = logger.clone();
             let container = container.clone();
             let remote = remote.clone();
 
             // Spawn task to handle the incoming RPC.
             let _ = tokio::spawn(async move {
-                match context::Context::new(rpc.request(), container) {
-                    Ok(ctx) => {
-                        remote.process_rpc(ctx, rpc).await;
-                    }
-                    Err(e) => {
-                        let response = utils::build_error_response(
-                            core_constants::CODE_BAD_FORMAT,
-                            format!("invalid request: {}", e),
-                        );
-                        if !rpc.respond(response) {
-                            error!(logger, "failed to respond to rpc");
-                        }
-                    }
-                }
+                remote.process_rpc(rpc, container).await;
             });
         }
     }

--- a/src/pitaya_core/src/utils.rs
+++ b/src/pitaya_core/src/utils.rs
@@ -42,19 +42,19 @@ where
     b
 }
 
-pub fn build_error_response<S, T>(code: S, msg: T) -> protos::Response
+pub fn build_error_response<S, T>(code: S, msg: T) -> Vec<u8>
 where
     S: ToString,
     T: ToString,
 {
-    protos::Response {
+    encode_proto(&protos::Response {
         error: Some(protos::Error {
             code: code.to_string(),
             msg: msg.to_string(),
             ..Default::default()
         }),
         ..Default::default()
-    }
+    })
 }
 
 pub fn build_request(

--- a/src/pitaya_etcd_nats_cluster/src/rpc_server.rs
+++ b/src/pitaya_etcd_nats_cluster/src/rpc_server.rs
@@ -5,9 +5,8 @@ use pitaya_core::{
     metrics::{self},
     protos, utils,
 };
-use prost::Message;
 use slog::{debug, error, info, o, trace, warn};
-use std::{sync::Arc, time::Instant};
+use std::sync::Arc;
 use tokio::sync::{mpsc, oneshot, RwLock};
 
 const RPC_LATENCY_METRIC: &str = "rpc_latency";
@@ -46,20 +45,12 @@ impl NatsRpcServer {
         sender: &mpsc::Sender<Rpc>,
         runtime_handle: tokio::runtime::Handle,
         conn: Arc<RwLock<Option<(nats::Connection, nats::subscription::Handler)>>>,
-        reporter: &metrics::ThreadSafeReporter,
     ) -> std::io::Result<()> {
         debug!(logger, "received nats message"; "message" => %message);
 
-        let rpc_start = Instant::now();
         let mut sender = sender.clone();
-        let req: protos::Request = Message::decode(message.data.as_ref())?;
-        let (responder, response_receiver) = oneshot::channel();
 
-        let route = if let Some(msg) = req.msg.as_ref() {
-            msg.route.to_string()
-        } else {
-            String::new()
-        };
+        let (responder, response_receiver) = oneshot::channel();
 
         let response_topic = match message.reply.take() {
             Some(topic) => topic,
@@ -69,7 +60,7 @@ impl NatsRpcServer {
             }
         };
 
-        match sender.try_send(Rpc::new(req, responder)) {
+        match sender.try_send(Rpc::new(message.data, responder)) {
             Ok(_) => {
                 // For the moment we are ignoring the handle returned by the task.
                 // Worst case scenario we will have to kill the task in the middle of its processing
@@ -79,10 +70,7 @@ impl NatsRpcServer {
                     let logger = logger.clone();
                     // runtime.spawn(async move {
                     trace!(logger, "spawning response receiver task");
-                    let reporter = reporter.clone();
                     runtime_handle.spawn(async move {
-                        Self::record_rpc_start(logger.clone(), reporter.clone()).await;
-
                         match response_receiver.await {
                             Ok(response) => {
                                 let conn = match conn.read().await.as_ref() {
@@ -97,9 +85,6 @@ impl NatsRpcServer {
                                 if let Err(err) = Self::respond(&conn, &response_topic, response)
                                 {
                                     error!(logger, "failed to respond rpc"; "error" => %err);
-                                    Self::record_rpc_end(logger.clone(), reporter.clone(), &route, rpc_start, false).await;
-                                } else {
-                                    Self::record_rpc_end(logger.clone(), reporter.clone(), &route, rpc_start, true).await;
                                 }
                             }
                             Err(e) => {
@@ -113,7 +98,6 @@ impl NatsRpcServer {
             Err(mpsc::error::TrySendError::Full(_)) => {
                 let _ = {
                     let logger = logger.clone();
-                    let reporter = reporter.clone();
                     runtime_handle.spawn(async move {
                         warn!(logger, "channel is full, dropping request");
                         let conn = match conn.read().await.as_ref() {
@@ -124,25 +108,17 @@ impl NatsRpcServer {
                             }
                         };
 
-                        let response = protos::Response {
+                        let response = utils::encode_proto(&protos::Response {
                             error: Some(protos::Error {
                                 code: "PIT-503".to_string(),
                                 msg: "server is overloaded".to_string(),
                                 ..Default::default()
                             }),
                             ..Default::default()
-                        };
+                        });
                         if let Err(err) = Self::respond(&conn, &response_topic, response) {
                             error!(logger, "failed to respond rpc"; "error" => %err);
                         }
-                        Self::record_rpc_end(
-                            logger.clone(),
-                            reporter.clone(),
-                            &route,
-                            rpc_start,
-                            false,
-                        )
-                        .await;
                     })
                 };
             }
@@ -154,46 +130,12 @@ impl NatsRpcServer {
         Ok(())
     }
 
-    async fn record_rpc_start(logger: slog::Logger, reporter: metrics::ThreadSafeReporter) {
-        metrics::add_to_gauge(
-            logger.clone(),
-            reporter.clone(),
-            RPCS_IN_FLIGHT_METRIC,
-            1.0,
-            &[],
-        )
-        .await;
-    }
-
-    async fn record_rpc_end(
-        logger: slog::Logger,
-        reporter: metrics::ThreadSafeReporter,
-        route: &str,
-        rpc_start: Instant,
-        success: bool,
-    ) {
-        // TODO(lhahn): we're unnecessarily locking the same mutex on the reporter two times.
-        // We should consider changing this if it becomes a problem in the future.
-
-        metrics::record_histogram_duration(
-            logger.clone(),
-            reporter.clone(),
-            RPC_LATENCY_METRIC,
-            rpc_start,
-            &[route, if success { "ok" } else { "failed" }],
-        )
-        .await;
-
-        metrics::add_to_gauge(logger, reporter, RPCS_IN_FLIGHT_METRIC, -1.0, &[]).await;
-    }
-
     fn respond(
         connection: &nats::Connection,
         reply_topic: &str,
-        res: protos::Response,
+        res: Vec<u8>,
     ) -> Result<(), Error> {
-        let buffer = utils::encode_proto(&res);
-        connection.publish(reply_topic, buffer).map_err(Error::Nats)
+        connection.publish(reply_topic, res).map_err(Error::Nats)
     }
 
     async fn register_metrics(&self) {
@@ -258,7 +200,6 @@ impl RpcServer for NatsRpcServer {
             let sender = rpc_sender;
             let runtime_handle = self.runtime_handle.clone();
             let connection = self.connection.clone();
-            let reporter = self.reporter.clone();
             nats_connection
                 .subscribe(&topic)
                 .map_err(Error::Nats)?
@@ -269,7 +210,6 @@ impl RpcServer for NatsRpcServer {
                         &sender,
                         runtime_handle.clone(),
                         connection.clone(),
-                        &reporter,
                     )
                 })
         };
@@ -324,11 +264,11 @@ mod tests {
         let handle = {
             tokio::spawn(async move {
                 while let Some(rpc) = rpc_server_conn.recv().await {
-                    let res = protos::Response {
+                    let res = utils::encode_proto(&protos::Response {
                         data: b"HEY, THIS IS THE SERVER".to_vec(),
                         error: None,
-                    };
-                    if rpc.responder().send(res).is_err() {
+                    });
+                    if !rpc.respond(res) {
                         panic!("failed to respond rpc");
                     }
                 }

--- a/src/pitaya_etcd_nats_cluster/src/rpc_server.rs
+++ b/src/pitaya_etcd_nats_cluster/src/rpc_server.rs
@@ -9,7 +9,6 @@ use slog::{debug, error, info, o, trace, warn};
 use std::sync::Arc;
 use tokio::sync::{mpsc, oneshot, RwLock};
 
-const RPC_LATENCY_METRIC: &str = "rpc_latency";
 const RPCS_IN_FLIGHT_METRIC: &str = "rpcs_in_flight";
 
 pub struct NatsRpcServer {
@@ -139,20 +138,6 @@ impl NatsRpcServer {
     }
 
     async fn register_metrics(&self) {
-        self.reporter
-            .write()
-            .await
-            .register_histogram(metrics::Opts {
-                kind: metrics::MetricKind::Histogram,
-                namespace: String::from("pitaya"),
-                subsystem: String::from("rpc"),
-                name: String::from(RPC_LATENCY_METRIC),
-                help: String::from("histogram of rpc latency in seconds"),
-                variable_labels: vec!["route".to_string(), "status".to_string()],
-                buckets: Some(metrics::exponential_buckets(0.0005, 2.0, 20)),
-            })
-            .expect("should not fail to register");
-
         self.reporter
             .write()
             .await


### PR DESCRIPTION
This PR changes Rust code so that it avoid Marshalling and Unmarshalling requests/responses unnecessarily. Now, it only forwards the RPC data directly to the FFI layer, without looking at it. The hypothesis is that this change will reduce CPU usage.

A downside of this change is that since Rust is not unmarshalling the RPC anymore, it cannot see which route is the RPC for, so the latency metrics now have to be reported on the c# side.